### PR TITLE
Fix selector discovery races and cache health metadata

### DIFF
--- a/examples/selector_cache_health_smoke.py
+++ b/examples/selector_cache_health_smoke.py
@@ -1,0 +1,133 @@
+"""Smoke test for explicit selector cache health states.
+
+This demonstrates the CAS-77 cache model behavior without touching your real
+``.yosoi`` directory:
+
+- active selector payloads still round-trip as selectors
+- explicit inactive snapshots stay in the cache but are omitted from selector
+  payloads used for extraction/verification
+- legacy ``primary: "NA"`` snapshots load as ``status="absent"``
+- cache summaries expose health counts without parsing selector values
+
+Run:
+    uv run python examples/selector_cache_health_smoke.py
+"""
+
+from __future__ import annotations
+
+import tempfile
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+warnings.filterwarnings(
+    'ignore',
+    message="Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.",
+    category=UserWarning,
+)
+
+from yosoi.models.snapshot import SelectorSnapshot, SnapshotStatus
+from yosoi.storage.persistence import SelectorStorage
+
+
+def isolated_storage(root: Path) -> SelectorStorage:
+    """Build SelectorStorage pointed at a temporary smoke directory."""
+    storage = SelectorStorage.__new__(SelectorStorage)
+    storage.storage_dir = str(root / 'selectors')
+    storage.content_dir = str(root / 'content')
+    Path(storage.storage_dir).mkdir(parents=True, exist_ok=True)
+    Path(storage.content_dir).mkdir(parents=True, exist_ok=True)
+    return storage
+
+
+def main() -> None:
+    console = Console()
+    now = datetime.now(timezone.utc)
+
+    with tempfile.TemporaryDirectory(prefix='yosoi-cache-health-') as tmp:
+        storage = isolated_storage(Path(tmp))
+        storage.save_snapshots(
+            'https://example.com/product/1',
+            {
+                'title': SelectorSnapshot(primary='h1.product-title', discovered_at=now),
+                'author': SelectorSnapshot(
+                    discovered_at=now,
+                    status=SnapshotStatus.ABSENT,
+                    status_reason='field not present on this domain',
+                ),
+                'price': SelectorSnapshot(
+                    discovered_at=now,
+                    status=SnapshotStatus.DISCOVERY_FAILED,
+                    status_reason='model returned no usable selector',
+                ),
+                'rating': SelectorSnapshot(
+                    discovered_at=now,
+                    status=SnapshotStatus.VERIFICATION_FAILED,
+                    status_reason='candidate selector matched no elements',
+                ),
+                'legacy_absent': SelectorSnapshot(primary='NA', discovered_at=now),
+            },
+        )
+
+        snapshots = storage.load_snapshots('example.com') or {}
+        selectors = storage.load_selectors('example.com') or {}
+        summary = storage.get_summary()
+        health = summary['domains'][0]['health'] if summary['domains'] else {}
+
+        console.print(
+            Panel.fit(
+                '[bold]Selector Cache Health Smoke[/bold]\ntemporary cache only; no real .yosoi files are modified',
+                border_style='cyan',
+            )
+        )
+
+        snapshot_table = Table(title='Snapshot Health')
+        snapshot_table.add_column('field')
+        snapshot_table.add_column('status')
+        snapshot_table.add_column('selector payload')
+        snapshot_table.add_column('reason')
+        for field_name, snapshot in sorted(snapshots.items()):
+            payload = selectors.get(field_name)
+            snapshot_table.add_row(
+                field_name,
+                snapshot.status.value,
+                repr(payload) if payload else '[dim]omitted[/dim]',
+                snapshot.status_reason or '',
+            )
+        console.print(snapshot_table)
+
+        health_table = Table(title='Summary Health Counts')
+        health_table.add_column('status')
+        health_table.add_column('count', justify='right')
+        for status in SnapshotStatus:
+            health_table.add_row(status.value, str(health.get(status.value, 0)))
+        console.print(health_table)
+
+        ok = (
+            selectors == {'title': {'primary': 'h1.product-title'}}
+            and snapshots['legacy_absent'].status == SnapshotStatus.ABSENT
+            and snapshots['legacy_absent'].primary is None
+            and health.get('active') == 1
+            and health.get('absent') == 2
+            and health.get('discovery_failed') == 1
+            and health.get('verification_failed') == 1
+        )
+        if not ok:
+            console.print(Panel.fit('[bold red]FAIL[/bold red] cache health smoke detected a regression'))
+            raise SystemExit(1)
+
+        console.print(
+            Panel.fit(
+                '[bold green]PASS[/bold green] inactive cache entries are explicit health states, '
+                'not fake selector values',
+                border_style='green',
+            )
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/selector_discovery_race_smoke.py
+++ b/examples/selector_discovery_race_smoke.py
@@ -1,0 +1,224 @@
+"""Smoke test for same-domain selector discovery race coordination.
+
+Scenario:
+    Three fresh qscrape URLs from the same domain ask for the same contract at
+    the same time. Yosoi should not spend LLM compute three times per field.
+
+What this demonstrates:
+    - A shared DiscoveryBus elects one leader per domain+field signature.
+    - Other same-domain workers wait for that field result and reuse it.
+    - A per-domain write lock serializes the final selector-cache writes only.
+
+This is a scheduler smoke. It uses a fake delayed field agent so it needs no
+network, browser, or LLM keys, and it prints the same counters you care about.
+
+Run:
+    uv run python examples/selector_discovery_race_smoke.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import warnings
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+warnings.filterwarnings(
+    'ignore',
+    message="Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.",
+    category=UserWarning,
+)
+
+import yosoi as ys
+from yosoi.core.discovery.bus import DiscoveryBus
+from yosoi.core.discovery.config import LLMConfig
+from yosoi.core.discovery.orchestrator import DiscoveryOrchestrator
+from yosoi.models.contract import Contract
+from yosoi.models.selectors import FieldSelectors, SelectorLevel
+from yosoi.models.snapshot import SelectorSnapshot
+
+URLS = [
+    'https://qscrape.dev/l2/eshop/products/alpha',
+    'https://qscrape.dev/l2/eshop/products/bravo',
+    'https://qscrape.dev/l2/eshop/products/charlie',
+]
+
+HTML = """
+<html>
+  <body>
+    <article class="product-card">
+      <h1 class="product-name">Smoke Product</h1>
+      <span class="price">$42.00</span>
+    </article>
+  </body>
+</html>
+"""
+
+
+class Product(Contract):
+    """Small qscrape-style product contract."""
+
+    name: str = ys.Title(description='Product name')
+    price: float = ys.Price(description='Product price as a number')
+
+
+@dataclass
+class RecordingStorage:
+    """Tiny storage test double that records cache reads/writes for terminal output."""
+
+    read_count: int = 0
+    write_count: int = 0
+    writes_in_flight: int = 0
+    peak_writes_in_flight: int = 0
+    saved_fields: list[list[str]] = field(default_factory=list)
+
+    def load_snapshots(self, _domain: str) -> dict[str, SelectorSnapshot] | None:
+        self.read_count += 1
+        return None
+
+    def load_selectors(self, _domain: str) -> dict[str, Any] | None:
+        self.read_count += 1
+        return None
+
+    def save_snapshots(self, _url: str, snapshots: dict[str, SelectorSnapshot]) -> str:
+        self.write_count += 1
+        self.writes_in_flight += 1
+        self.peak_writes_in_flight = max(self.peak_writes_in_flight, self.writes_in_flight)
+        try:
+            self.saved_fields.append(sorted(snapshots))
+            return 'memory://selectors_qscrape_dev.json'
+        finally:
+            self.writes_in_flight -= 1
+
+    def save_selectors(self, _url: str, _selectors: dict[str, Any], *, _verified: bool = False) -> str:
+        raise AssertionError('orchestrator should persist snapshots explicitly')
+
+
+class CountingAgent:
+    """Fake field agent that behaves like a slow LLM call and records compute."""
+
+    def __init__(self, calls: Counter[str], leaders: list[str]) -> None:
+        self._calls = calls
+        self._leaders = leaders
+
+    async def discover_field(
+        self,
+        field_name: str,
+        _field_description: str,
+        _field_hint: str | None,
+        _discovery_input: Any,
+        _target_level: SelectorLevel,
+        _is_container: bool = False,
+    ) -> FieldSelectors | None:
+        self._calls[field_name] += 1
+        self._leaders.append(field_name)
+        await asyncio.sleep(0.15)
+        if field_name == 'name':
+            return FieldSelectors(primary='.product-name')
+        if field_name == 'price':
+            return FieldSelectors(primary='.price')
+        if field_name == 'root':
+            return FieldSelectors(primary='.product-card')
+        return None
+
+
+async def run_one(
+    url: str,
+    bus: DiscoveryBus,
+    write_lock: asyncio.Lock,
+    storage: RecordingStorage,
+    calls: Counter[str],
+    leaders: list[str],
+) -> tuple[str, dict[str, dict[str, Any]] | None, float]:
+    orchestrator = DiscoveryOrchestrator(
+        contract=Product,
+        llm_config=LLMConfig(provider='groq', model_name='fake-smoke-model', api_key='unused'),
+        storage=storage,  # type: ignore[arg-type]
+        target_level=SelectorLevel.CSS,
+        max_concurrent=3,
+        bus=bus,
+        write_lock=write_lock,
+        console=Console(quiet=True),
+    )
+    orchestrator._agent = CountingAgent(calls, leaders)  # type: ignore[assignment]
+
+    started = time.perf_counter()
+    selectors = await orchestrator.discover_selectors(HTML, url=url, force=True)
+    return url, selectors, (time.perf_counter() - started) * 1000
+
+
+async def main() -> None:
+    console = Console()
+    bus = DiscoveryBus()
+    write_lock = asyncio.Lock()
+    storage = RecordingStorage()
+    calls: Counter[str] = Counter()
+    leaders: list[str] = []
+
+    console.print(
+        Panel.fit(
+            '[bold]Selector Discovery Race Smoke[/bold]\n'
+            '3 fresh qscrape.dev URLs, same Product contract, same domain cache bucket',
+            border_style='cyan',
+        )
+    )
+
+    results = await asyncio.gather(
+        *(run_one(url, bus, write_lock, storage, calls, leaders) for url in URLS),
+    )
+
+    expected_fields = {'name', 'price', 'root'}
+    expected_compute = dict.fromkeys(expected_fields, 1)
+    ok_compute = all(calls[field_name] == 1 for field_name in expected_fields)
+    ok_results = all(selectors is not None and expected_fields <= set(selectors) for _url, selectors, _ms in results)
+    ok_writes = storage.peak_writes_in_flight == 1 and storage.write_count == len(URLS)
+
+    url_table = Table(title='Worker Results')
+    url_table.add_column('URL')
+    url_table.add_column('selector fields')
+    url_table.add_column('elapsed', justify='right')
+    for url, selectors, elapsed_ms in results:
+        url_table.add_row(url, ', '.join(sorted(selectors or {})), f'{elapsed_ms:.0f} ms')
+    console.print(url_table)
+
+    compute_table = Table(title='LLM Compute Calls Avoided')
+    compute_table.add_column('field')
+    compute_table.add_column('actual fake LLM calls', justify='right')
+    compute_table.add_column('naive calls without bus', justify='right')
+    compute_table.add_column('status')
+    for field_name in sorted(expected_fields):
+        actual = calls[field_name]
+        status = '[green]shared once[/green]' if actual == expected_compute[field_name] else '[red]duplicated[/red]'
+        compute_table.add_row(field_name, str(actual), str(len(URLS)), status)
+    console.print(compute_table)
+
+    lock_table = Table(title='Cache Write Coordination')
+    lock_table.add_column('metric')
+    lock_table.add_column('value', justify='right')
+    lock_table.add_row('final cache writes', str(storage.write_count))
+    lock_table.add_row('peak simultaneous writes', str(storage.peak_writes_in_flight))
+    lock_table.add_row('saved field sets', '; '.join(','.join(fields) for fields in storage.saved_fields))
+    console.print(lock_table)
+
+    if not (ok_compute and ok_results and ok_writes):
+        console.print(Panel.fit('[bold red]FAIL[/bold red] selector discovery race coordination regressed'))
+        raise SystemExit(1)
+
+    avoided = (len(URLS) - 1) * len(expected_fields)
+    console.print(
+        Panel.fit(
+            f'[bold green]PASS[/bold green] one discovery per field, {avoided} duplicate fake LLM calls avoided; '
+            'cache writes stayed serialized',
+            border_style='green',
+        )
+    )
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/unit/core/discovery/test_field_task.py
+++ b/tests/unit/core/discovery/test_field_task.py
@@ -6,6 +6,7 @@ import pytest
 
 from yosoi.core.discovery.field_task import FieldTaskResult, run_field_task
 from yosoi.models.selectors import FieldSelectors, SelectorLevel
+from yosoi.models.snapshot import SnapshotStatus
 from yosoi.prompts.discovery import DiscoveryInput
 from yosoi.utils.exceptions import LLMGenerationError
 
@@ -221,6 +222,26 @@ async def test_invalid_cached_entry_triggers_rediscovery(mock_agent):
     assert result.from_cache is False
     assert result.selectors is not None
     mock_agent.discover_field.assert_called()
+
+
+@pytest.mark.anyio
+async def test_absent_cache_status_skips_discovery(mock_agent):
+    cached_entry = {'status': SnapshotStatus.ABSENT, 'status_reason': 'not on this domain'}
+
+    result = await run_field_task(
+        field_name='headline',
+        field_description='Article title',
+        field_hint=None,
+        discovery_input=_DISCOVERY_INPUT,
+        html=_HTML,
+        agent=mock_agent,
+        cached_entry=cached_entry,
+        max_level=SelectorLevel.CSS,
+    )
+
+    assert result.selectors is None
+    assert result.from_cache is False
+    mock_agent.discover_field.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tests/unit/core/discovery/test_orchestrator.py
+++ b/tests/unit/core/discovery/test_orchestrator.py
@@ -119,7 +119,7 @@ async def test_discover_selectors_partial_results_preserved(orchestrator, mocker
 
 
 @pytest.mark.anyio
-async def test_failed_fields_are_persisted_as_na_sentinels(orchestrator, mocker):
+async def test_failed_fields_are_persisted_as_absent_snapshots(orchestrator, mocker):
     async def mock_run_field_task(**kwargs):
         from yosoi.core.discovery.field_task import FieldTaskResult
 
@@ -131,14 +131,15 @@ async def test_failed_fields_are_persisted_as_na_sentinels(orchestrator, mocker)
         return FieldTaskResult(field_name=name, selectors=None, from_cache=False, escalated_to=None)
 
     mocker.patch('yosoi.core.discovery.orchestrator.run_field_task', new=mock_run_field_task)
-    save_spy = mocker.patch.object(orchestrator._storage, 'save_selectors')
+    save_spy = mocker.patch.object(orchestrator._storage, 'save_snapshots')
 
     result = await orchestrator.discover_selectors(_HTML, 'https://example.com')
 
     assert result is not None
     saved = save_spy.call_args.args[1]
-    assert saved['headline']['primary'] == {'type': 'css', 'value': 'h1.title'}
-    assert saved['author'] == {'primary': 'NA'}
+    assert saved['headline'].primary == {'type': 'css', 'value': 'h1.title'}
+    assert saved['author'].status == 'absent'
+    assert saved['author'].primary is None
 
 
 @pytest.mark.anyio
@@ -254,7 +255,7 @@ async def test_save_selectors_called_with_url(orchestrator, mocker):
         return FieldTaskResult(field_name=name, selectors=sel, from_cache=False, escalated_to=None)
 
     mocker.patch('yosoi.core.discovery.orchestrator.run_field_task', new=mock_run_field_task)
-    save_spy = mocker.patch.object(orchestrator._storage, 'save_selectors')
+    save_spy = mocker.patch.object(orchestrator._storage, 'save_snapshots')
 
     await orchestrator.discover_selectors(_HTML, 'https://example.com/article')
 
@@ -282,7 +283,7 @@ async def test_save_selectors_not_called_without_url(orchestrator, mocker):
 
 @pytest.mark.anyio
 async def test_storage_read_called_once_not_per_field(orchestrator, mocker):
-    """load_selectors must be called exactly once, not N times (one per field)."""
+    """load_snapshots must be called exactly once, not N times (one per field)."""
 
     async def mock_run_field_task(**kwargs):
         from yosoi.core.discovery.field_task import FieldTaskResult
@@ -292,7 +293,7 @@ async def test_storage_read_called_once_not_per_field(orchestrator, mocker):
         return FieldTaskResult(field_name=name, selectors=sel, from_cache=False, escalated_to=None)
 
     mocker.patch('yosoi.core.discovery.orchestrator.run_field_task', new=mock_run_field_task)
-    load_spy = mocker.patch.object(orchestrator._storage, 'load_selectors', return_value={})
+    load_spy = mocker.patch.object(orchestrator._storage, 'load_snapshots', return_value={})
 
     await orchestrator.discover_selectors(_HTML, 'https://example.com')
 
@@ -325,7 +326,7 @@ async def test_pinned_root_included_in_orchestrator_save(llm_config, mock_storag
         )
 
     mocker.patch('yosoi.core.discovery.orchestrator.run_field_task', new=mock_run_field_task)
-    save_spy = mocker.patch.object(mock_storage, 'save_selectors')
+    save_spy = mocker.patch.object(mock_storage, 'save_snapshots')
 
     result = await orchestrator.discover_selectors(_HTML, 'https://example.com')
 
@@ -335,11 +336,11 @@ async def test_pinned_root_included_in_orchestrator_save(llm_config, mock_storag
     assert result['root']['primary']['type'] == 'css'
     assert result['root']['primary']['value'] == '.product-card'
 
-    # The map passed to save_selectors must also include root in the same format
+    # The snapshots passed to save_snapshots must also include root in the same format
     assert save_spy.called
     saved_map = save_spy.call_args[0][1]
     assert 'root' in saved_map
-    assert saved_map['root']['primary']['value'] == '.product-card'
+    assert saved_map['root'].primary['value'] == '.product-card'
 
 
 @pytest.mark.anyio

--- a/tests/unit/core/fetcher/test_voiddriver_pool_isolation.py
+++ b/tests/unit/core/fetcher/test_voiddriver_pool_isolation.py
@@ -1,0 +1,93 @@
+"""Regression coverage for same-domain concurrent VoidCrawl pool use."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from yosoi.core.fetcher.dom import LoadResult
+from yosoi.core.fetcher.voiddriver import _VoidCrawlFetcher
+
+
+class _ConcurrentAcquirePool:
+    def __init__(self, tabs: list[_ConcurrentTab]) -> None:
+        self._tabs = tabs
+        self.active = 0
+        self.max_active = 0
+
+    def acquire(self) -> _AcquireContext:
+        return _AcquireContext(self, self._tabs.pop(0))
+
+
+class _AcquireContext:
+    def __init__(self, pool: _ConcurrentAcquirePool, tab: _ConcurrentTab) -> None:
+        self._pool = pool
+        self._tab = tab
+
+    async def __aenter__(self) -> _ConcurrentTab:
+        self._pool.active += 1
+        self._pool.max_active = max(self._pool.max_active, self._pool.active)
+        return self._tab
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        self._pool.active -= 1
+
+
+class _ConcurrentTab:
+    def __init__(self, name: str, started: list[str], both_started: asyncio.Event) -> None:
+        self.name = name
+        self._started = started
+        self._both_started = both_started
+        self.urls: list[str] = []
+
+    async def goto(self, url: str, timeout: float) -> None:
+        self.urls.append(url)
+        self._started.append(self.name)
+        if len(self._started) == 2:
+            self._both_started.set()
+        await asyncio.wait_for(self._both_started.wait(), timeout=1)
+
+
+class _TabEchoDOMLoader:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    async def run(self, tab: _ConcurrentTab) -> LoadResult:
+        body = f'<article>{tab.name}</article>' + ('x' * 600)
+        return LoadResult(
+            success=True,
+            content_start=1,
+            content_final=1,
+            elapsed_ms=1,
+            html=f'<html><body>{body}</body></html>',
+        )
+
+
+@pytest.mark.asyncio
+async def test_same_domain_concurrent_fetches_use_distinct_acquired_tabs(mocker) -> None:
+    """Concurrent same-origin fetches must not serialize or share tab navigation state."""
+    both_started = asyncio.Event()
+    started: list[str] = []
+    tabs = [_ConcurrentTab('tab-a', started, both_started), _ConcurrentTab('tab-b', started, both_started)]
+    pool = _ConcurrentAcquirePool(tabs)
+    fetcher = _VoidCrawlFetcher(min_content_length=1)
+    fetcher._pool = pool
+    mocker.patch('yosoi.core.fetcher.voiddriver.DOMLoader', _TabEchoDOMLoader)
+
+    first, second = await asyncio.wait_for(
+        asyncio.gather(
+            fetcher._do_fetch('https://example.com/a', time.time(), 'fetch'),
+            fetcher._do_fetch('https://example.com/b', time.time(), 'fetch'),
+        ),
+        timeout=1,
+    )
+
+    assert pool.max_active == 2
+    assert started == ['tab-a', 'tab-b']
+    assert first.html is not None
+    assert second.html is not None
+    assert 'tab-a' in first.html
+    assert 'tab-b' in second.html

--- a/tests/unit/core/test_pipeline_granular.py
+++ b/tests/unit/core/test_pipeline_granular.py
@@ -10,7 +10,7 @@ from yosoi.core.pipeline import Pipeline
 from yosoi.models.contract import Contract
 from yosoi.models.results import FieldVerificationResult, VerificationResult
 from yosoi.models.selectors import SelectorLevel
-from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot
+from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot, SnapshotStatus
 from yosoi.storage.tracking import DomainStats
 
 # ---------------------------------------------------------------------------
@@ -147,6 +147,27 @@ class TestVerifyPerField:
         assert verdicts['title'] == CacheVerdict.STALE
         assert verdicts['price'] == CacheVerdict.STALE
         assert stub._last_level_distribution == {}
+
+    def test_absent_snapshot_is_not_verified_or_marked_stale(self, mocker):
+        stub = _make_pipeline_stub(mocker)
+        snapshots = {
+            'title': _make_snapshot('h1.title'),
+            'author': SelectorSnapshot(
+                discovered_at=datetime.now(timezone.utc),
+                status=SnapshotStatus.ABSENT,
+                status_reason='not present on this domain',
+            ),
+        }
+
+        stub.verifier._verify_field.return_value = FieldVerificationResult(
+            field_name='title', status='verified', working_level='primary', selector='h1.title'
+        )
+
+        verdicts = stub._verify_per_field('<html><h1 class="title">X</h1></html>', snapshots)
+
+        assert verdicts['title'] == CacheVerdict.FRESH
+        assert verdicts['author'] == CacheVerdict.FRESH
+        stub.verifier._verify_field.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_persistence.py
+++ b/tests/unit/storage/test_persistence.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+from yosoi.models.snapshot import SelectorSnapshot, SnapshotStatus
 from yosoi.storage.persistence import SelectorStorage
 
 
@@ -109,6 +110,19 @@ def test_get_summary_domain_has_fields(storage):
     domain_info = summary['domains'][0]
     assert 'fields' in domain_info
     assert 'title' in domain_info['fields']
+
+
+def test_get_summary_includes_snapshot_health_counts(storage):
+    snapshots = {
+        'title': SelectorSnapshot(primary='h1', discovered_at='2026-01-01T00:00:00Z'),
+        'author': SelectorSnapshot(discovered_at='2026-01-01T00:00:00Z', status=SnapshotStatus.ABSENT),
+    }
+    storage.save_snapshots('https://example.com', snapshots)
+
+    domain_info = storage.get_summary()['domains'][0]
+
+    assert domain_info['health']['active'] == 1
+    assert domain_info['health']['absent'] == 1
 
 
 def test_get_summary_domain_has_domain_key(storage):

--- a/tests/unit/storage/test_snapshot_persistence.py
+++ b/tests/unit/storage/test_snapshot_persistence.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot
+from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot, SnapshotStatus
 from yosoi.storage.persistence import SelectorStorage
 
 
@@ -46,6 +46,23 @@ class TestSaveLoadSnapshots:
     def test_load_nonexistent_returns_none(self, storage):
         assert storage.load_snapshots('nonexistent.com') is None
 
+    def test_legacy_na_primary_loads_as_absent_snapshot(self, storage):
+        now = datetime.now(timezone.utc)
+        snapshots = {
+            'author': SelectorSnapshot(
+                primary='NA',
+                discovered_at=now,
+            ),
+        }
+
+        storage.save_snapshots('https://example.com/item', snapshots)
+        loaded = storage.load_snapshots('example.com')
+
+        assert loaded is not None
+        assert loaded['author'].status == SnapshotStatus.ABSENT
+        assert loaded['author'].primary is None
+        assert storage.load_selectors('example.com') == {}
+
 
 class TestSaveLoadSelectors:
     def test_save_selectors_writes_snapshot_format(self, storage):
@@ -59,6 +76,15 @@ class TestSaveLoadSelectors:
         assert snapshots is not None
         assert 'title' in snapshots
         assert snapshots['title'].primary == 'h1.title'
+
+    def test_save_selectors_migrates_legacy_absent_sentinel(self, storage):
+        storage.save_selectors('https://example.com/article', {'author': {'primary': 'NA'}})
+
+        snapshots = storage.load_snapshots('example.com')
+
+        assert snapshots is not None
+        assert snapshots['author'].status == SnapshotStatus.ABSENT
+        assert snapshots['author'].primary is None
 
     def test_load_selectors_strips_audit_metadata(self, storage):
         now = datetime.now(timezone.utc)
@@ -75,6 +101,17 @@ class TestSaveLoadSelectors:
         assert 'title' in loaded
         assert loaded['title'] == {'primary': {'type': 'css', 'value': 'h1.title'}}
         assert 'discovered_at' not in loaded['title']
+
+    def test_load_selectors_omits_explicit_absent_snapshots(self, storage):
+        now = datetime.now(timezone.utc)
+        snapshots = {
+            'title': SelectorSnapshot(primary='h1', discovered_at=now),
+            'author': SelectorSnapshot(discovered_at=now, status=SnapshotStatus.ABSENT),
+        }
+
+        storage.save_snapshots('https://example.com/page', snapshots)
+
+        assert storage.load_selectors('example.com') == {'title': {'primary': 'h1'}}
 
     def test_load_selectors_nonexistent_returns_none(self, storage):
         assert storage.load_selectors('nothing.com') is None

--- a/yosoi/__init__.py
+++ b/yosoi/__init__.py
@@ -41,7 +41,7 @@ from yosoi.integrations import ClaudeSDKModel, OpenCodeModel
 from yosoi.models.contract import Contract
 from yosoi.models.defaults import JobPosting, NewsArticle, Product, Video
 from yosoi.models.selectors import FieldSelectors, SelectorEntry, SelectorLevel, css, discover, jsonld, regex, xpath
-from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot, SnapshotMap
+from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot, SnapshotMap, SnapshotStatus
 from yosoi.types import (
     Author,
     BodyText,
@@ -83,6 +83,7 @@ __all__ = [
     'SelectorLevel',
     'SelectorSnapshot',
     'SnapshotMap',
+    'SnapshotStatus',
     'TelemetryConfig',
     'Title',
     'Url',

--- a/yosoi/__init__.pyi
+++ b/yosoi/__init__.pyi
@@ -22,6 +22,7 @@ from yosoi.models.selectors import SelectorLevel as SelectorLevel
 from yosoi.models.snapshot import CacheVerdict as CacheVerdict
 from yosoi.models.snapshot import SelectorSnapshot as SelectorSnapshot
 from yosoi.models.snapshot import SnapshotMap as SnapshotMap
+from yosoi.models.snapshot import SnapshotStatus as SnapshotStatus
 from yosoi.types.base import YosoiType as YosoiType
 from yosoi.types.field import Field as Field
 from yosoi.types.registry import register_coercion as register_coercion

--- a/yosoi/core/discovery/field_task.py
+++ b/yosoi/core/discovery/field_task.py
@@ -12,6 +12,7 @@ from tenacity import RetryError
 
 from yosoi.core.verification.verifier import SelectorVerifier
 from yosoi.models.selectors import FieldSelectors, SelectorLevel
+from yosoi.models.snapshot import SnapshotStatus
 from yosoi.prompts.discovery import DiscoveryInput
 from yosoi.utils import observability as obs
 from yosoi.utils.exceptions import LLMGenerationError
@@ -82,9 +83,20 @@ async def _discover_field(
 
     # --- 1. Cache check ---
     if cached_entry is not None:
-        # NA sentinel — field was tried before and doesn't exist on this domain
-        if cached_entry.get('primary') == 'NA':
-            logger.info('Field known absent from cache: %s', field_name)
+        status = cached_entry.get('status')
+        if (
+            status
+            in {
+                SnapshotStatus.ABSENT,
+                SnapshotStatus.ABSENT.value,
+                SnapshotStatus.DISCOVERY_FAILED,
+                SnapshotStatus.DISCOVERY_FAILED.value,
+                SnapshotStatus.VERIFICATION_FAILED,
+                SnapshotStatus.VERIFICATION_FAILED.value,
+            }
+            or cached_entry.get('primary') == 'NA'
+        ):
+            logger.info('Field cache is inactive: %s status=%s', field_name, status)
             return failure
 
         try:

--- a/yosoi/core/discovery/orchestrator.py
+++ b/yosoi/core/discovery/orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 from rich.console import Console
@@ -14,6 +15,7 @@ from yosoi.core.discovery.field_agent import FieldDiscoveryAgent
 from yosoi.core.discovery.field_task import FieldTaskResult, run_field_task
 from yosoi.models.contract import Contract
 from yosoi.models.selectors import SelectorLevel
+from yosoi.models.snapshot import SelectorSnapshot, SnapshotStatus, selector_dict_to_snapshot
 from yosoi.prompts.discovery import DiscoveryInput
 from yosoi.storage.persistence import SelectorStorage
 from yosoi.utils import observability as obs
@@ -187,8 +189,13 @@ class DiscoveryOrchestrator:
 
         semaphore = asyncio.Semaphore(self._max_concurrent)
 
-        # Load the full domain selector map once — avoids N redundant file reads
-        existing = self._storage.load_selectors(domain) or {}
+        # Load the full domain selector map once — avoids N redundant file reads.
+        # Keep snapshot health metadata so absent/failed fields are not mistaken
+        # for malformed selector payloads.
+        snapshots = self._storage.load_snapshots(domain) or {}
+        from yosoi.models.snapshot import snapshot_to_cache_entry
+
+        existing = {name: snapshot_to_cache_entry(snapshot) for name, snapshot in snapshots.items()}
 
         task_specs = self._build_task_specs(field_descs, hints, stale_fields)
 
@@ -223,20 +230,20 @@ class DiscoveryOrchestrator:
         if contract_root:
             merged['root'] = {'primary': contract_root.model_dump(exclude_none=True)}
 
-        persisted = dict(merged)
-        for field_name in absent_fields:
-            persisted[field_name] = {'primary': 'NA'}
+        persisted_snapshots: dict[str, SelectorSnapshot] | None = None
+        if url and stale_fields is None:
+            persisted_snapshots = self._build_persisted_snapshots(merged, absent_fields)
 
         # Check if all non-root fields failed
         non_container = {k: v for k, v in merged.items() if k != 'root'}
         if not non_container:
             obs.warning('All field tasks returned None', url=url_context)
-            if url and stale_fields is None and persisted:
+            if url and stale_fields is None and persisted_snapshots:
                 if self._write_lock is not None:
                     async with self._write_lock:
-                        self._storage.save_selectors(url, persisted)
+                        self._storage.save_snapshots(url, persisted_snapshots)
                 else:
-                    self._storage.save_selectors(url, persisted)
+                    self._storage.save_snapshots(url, persisted_snapshots)
             return None
 
         logger.info(
@@ -252,14 +259,29 @@ class DiscoveryOrchestrator:
 
         # Single write — avoids read-modify-write races across concurrent tasks
         # Skip save for partial rediscovery (pipeline handles merge + save)
-        if url and stale_fields is None:
+        if url and stale_fields is None and persisted_snapshots is not None:
             if self._write_lock is not None:
                 async with self._write_lock:
-                    self._storage.save_selectors(url, persisted)
+                    self._storage.save_snapshots(url, persisted_snapshots)
             else:
-                self._storage.save_selectors(url, persisted)
+                self._storage.save_snapshots(url, persisted_snapshots)
 
         return merged
+
+    def _build_persisted_snapshots(self, merged: SelectorMap, absent_fields: set[str]) -> dict[str, SelectorSnapshot]:
+        """Build explicit-health snapshots for the final domain cache write."""
+        now = datetime.now(timezone.utc)
+        snapshots = {
+            field_name: selector_dict_to_snapshot(field_data, discovered_at=now)
+            for field_name, field_data in merged.items()
+        }
+        for field_name in absent_fields:
+            snapshots[field_name] = SelectorSnapshot(
+                discovered_at=now,
+                status=SnapshotStatus.ABSENT,
+                status_reason='field discovery returned no verified selector',
+            )
+        return snapshots
 
     def _merge_results(
         self,

--- a/yosoi/core/pipeline.py
+++ b/yosoi/core/pipeline.py
@@ -779,7 +779,7 @@ class Pipeline:
         self.logger.info('Using cached selectors domain=%s url=%s', domain, url)
 
         if skip_verification:
-            existing = {name: snapshot_to_selector_dict(snap) for name, snap in snapshots.items()}
+            existing = {name: data for name, snap in snapshots.items() if (data := snapshot_to_selector_dict(snap))}
             items, cache_valid = await self._extract_with_cached(url, fetcher, existing, skip_verification)
             if not cache_valid:
                 return None
@@ -794,7 +794,9 @@ class Pipeline:
 
         fetch_result = await self._fetch_and_clean_for_cache(url, fetcher)
         if fetch_result is None:
-            existing_for_payload = {name: snapshot_to_selector_dict(snap) for name, snap in snapshots.items()}
+            existing_for_payload = {
+                name: data for name, snap in snapshots.items() if (data := snapshot_to_selector_dict(snap))
+            }
             return self._yield_cached_items(
                 None,
                 url,
@@ -885,7 +887,7 @@ class Pipeline:
     ) -> AsyncIterator[ContentMap]:
         """All cached selectors verified — extract content."""
         self.console.print(f'[success]✓ All {len(fresh_fields)} cached selectors verified[/success]')
-        existing = {name: snapshot_to_selector_dict(snap) for name, snap in snapshots.items()}
+        existing = {name: data for name, snap in snapshots.items() if (data := snapshot_to_selector_dict(snap))}
         root_entry = self._resolve_root(existing)
         container_selector = self._root_value(root_entry)
         with observability.span('extract', url=url, mode='cache', container=container_selector or 'single'):
@@ -984,6 +986,9 @@ class Pipeline:
         field_levels: dict[str, str] = {}
 
         for field_name, snap in snapshots.items():
+            if not snap.is_active:
+                verdicts[field_name] = CacheVerdict.FRESH
+                continue
             sel_dict = snapshot_to_selector_dict(snap)
             field_result = self.verifier._verify_field(sel, field_name, sel_dict, self.selector_level)
             verdicts[field_name] = CacheVerdict.FRESH if field_result.status == 'verified' else CacheVerdict.STALE
@@ -1059,7 +1064,9 @@ class Pipeline:
         from yosoi.models.snapshot import selector_dict_to_snapshot as _to_snap
 
         merged: SelectorMap = {
-            name: snapshot_to_selector_dict(snap) for name, snap in snapshots.items() if name in fresh_fields
+            name: data
+            for name, snap in snapshots.items()
+            if name in fresh_fields and (data := snapshot_to_selector_dict(snap))
         }
         if new_selectors:
             merged.update(new_selectors)

--- a/yosoi/models/__init__.py
+++ b/yosoi/models/__init__.py
@@ -10,7 +10,7 @@ from yosoi.models.results import (
     VerificationResult,
 )
 from yosoi.models.selectors import FieldSelectors, SelectorEntry, SelectorLevel
-from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot, SnapshotMap
+from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot, SnapshotMap, SnapshotStatus
 
 __all__ = [
     'CacheVerdict',
@@ -26,5 +26,6 @@ __all__ = [
     'SelectorLevel',
     'SelectorSnapshot',
     'SnapshotMap',
+    'SnapshotStatus',
     'VerificationResult',
 ]

--- a/yosoi/models/snapshot.py
+++ b/yosoi/models/snapshot.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import AwareDatetime, BaseModel, Field
+from pydantic import AwareDatetime, BaseModel, Field, model_validator
 
 
 class CacheVerdict(str, Enum):
@@ -26,6 +26,15 @@ class CacheVerdict(str, Enum):
     FRESH = 'fresh'
     STALE = 'stale'
     DEGRADED = 'degraded'  # stub: treated as STALE for now, FUTURE used for event driven pipeline healing when pipeline_mode != maintenance or offline
+
+
+class SnapshotStatus(str, Enum):
+    """Operational health state for a cached field snapshot."""
+
+    ACTIVE = 'active'
+    ABSENT = 'absent'
+    DISCOVERY_FAILED = 'discovery_failed'
+    VERIFICATION_FAILED = 'verification_failed'
 
 
 class SelectorSnapshot(BaseModel):
@@ -58,6 +67,28 @@ class SelectorSnapshot(BaseModel):
     failure_count: int = 0
     source: Literal['discovered', 'pinned', 'override'] = 'discovered'
     parent_root: str | None = None
+    status: SnapshotStatus = SnapshotStatus.ACTIVE
+    status_reason: str | None = None
+
+    @model_validator(mode='before')
+    @classmethod
+    def _migrate_legacy_absent_sentinel(cls, data: Any) -> Any:
+        """Map legacy ``primary: "NA"`` cache entries to explicit absent status."""
+        if not isinstance(data, dict) or data.get('primary') != 'NA':
+            return data
+
+        migrated = dict(data)
+        migrated['primary'] = None
+        migrated['fallback'] = None
+        migrated['tertiary'] = None
+        migrated.setdefault('status', SnapshotStatus.ABSENT)
+        migrated.setdefault('status_reason', 'legacy primary=NA sentinel')
+        return migrated
+
+    @property
+    def is_active(self) -> bool:
+        """Whether this snapshot contains selector payload that should be used."""
+        return self.status == SnapshotStatus.ACTIVE
 
 
 class SnapshotMap(BaseModel):
@@ -82,6 +113,8 @@ class SnapshotMap(BaseModel):
 
 def snapshot_to_selector_dict(snap: SelectorSnapshot) -> dict[str, Any]:
     """Extract just the primary/fallback/tertiary selector data from a snapshot."""
+    if not snap.is_active:
+        return {}
     result: dict[str, Any] = {}
     if snap.primary is not None:
         result['primary'] = snap.primary
@@ -89,6 +122,15 @@ def snapshot_to_selector_dict(snap: SelectorSnapshot) -> dict[str, Any]:
         result['fallback'] = snap.fallback
     if snap.tertiary is not None:
         result['tertiary'] = snap.tertiary
+    return result
+
+
+def snapshot_to_cache_entry(snap: SelectorSnapshot) -> dict[str, Any]:
+    """Return selector payload plus snapshot health for field-task cache checks."""
+    result = snapshot_to_selector_dict(snap)
+    result['status'] = snap.status
+    if snap.status_reason is not None:
+        result['status_reason'] = snap.status_reason
     return result
 
 
@@ -110,12 +152,15 @@ def selector_dict_to_snapshot(
 ) -> SelectorSnapshot:
     """Wrap a raw selector dict into a SelectorSnapshot."""
     ts = _ensure_utc(discovered_at) or datetime.now(timezone.utc)
+    status = SnapshotStatus.ABSENT if field_data.get('primary') == 'NA' else SnapshotStatus.ACTIVE
     return SelectorSnapshot(
-        primary=field_data.get('primary'),
-        fallback=field_data.get('fallback'),
-        tertiary=field_data.get('tertiary'),
+        primary=None if status != SnapshotStatus.ACTIVE else field_data.get('primary'),
+        fallback=None if status != SnapshotStatus.ACTIVE else field_data.get('fallback'),
+        tertiary=None if status != SnapshotStatus.ACTIVE else field_data.get('tertiary'),
         discovered_at=ts,
         last_verified_at=_ensure_utc(last_verified_at),
         source=source,
         parent_root=parent_root,
+        status=status,
+        status_reason='legacy primary=NA sentinel' if status == SnapshotStatus.ABSENT else None,
     )

--- a/yosoi/storage/persistence.py
+++ b/yosoi/storage/persistence.py
@@ -15,6 +15,7 @@ from yosoi.models.snapshot import (
     CacheVerdict,
     SelectorSnapshot,
     SnapshotMap,
+    SnapshotStatus,
     selector_dict_to_snapshot,
     snapshot_to_selector_dict,
 )
@@ -81,7 +82,7 @@ class SelectorStorage:
         snapshots = self.load_snapshots(domain)
         if snapshots is None:
             return None
-        return {name: snapshot_to_selector_dict(snap) for name, snap in snapshots.items()}
+        return {name: data for name, snap in snapshots.items() if (data := snapshot_to_selector_dict(snap))}
 
     def load_field_selector(self, domain: str, field_name: str) -> dict[str, Any] | None:
         """Return raw selector dict for a single field, or None if not cached.
@@ -234,11 +235,15 @@ class SelectorStorage:
             if snapshots:
                 # Use earliest discovered_at as the domain-level timestamp
                 earliest = min((s.discovered_at for s in snapshots.values()), default=None)
+                health_counts = {status.value: 0 for status in SnapshotStatus}
+                for snap in snapshots.values():
+                    health_counts[snap.status.value] += 1
                 summary['domains'].append(
                     {
                         'domain': domain,
                         'discovered_at': earliest.isoformat() if earliest else None,
                         'fields': list(snapshots.keys()),
+                        'health': health_counts,
                     }
                 )
 


### PR DESCRIPTION
## Intent

Fix the same-domain selector discovery race surfaced by CAS-60 and make selector cache absence/health explicit for CAS-77.

This PR separates operational cache state from selector payloads. The LLM/discovery agent still only proposes selectors or returns no selector; Yosoi deterministically records cache health based on what happened during discovery, verification, and persistence.

Linear:
- CAS-60: Fix same-domain races in pool / tab recycling
- CAS-77: Make selector cache absence and health explicit

## Changes

- Added `SnapshotStatus` to selector snapshots:
  - `active`
  - `absent`
  - `discovery_failed`
  - `verification_failed`
- Added `status_reason` to snapshots for human-readable cache-health context.
- Migrated legacy `primary: "NA"` cache entries to explicit `status="absent"` in memory.
- Stopped passing inactive snapshots into selector verification/extraction payloads.
- Updated field-task cache checks to skip inactive cache entries deterministically.
- Updated orchestrator failed-field persistence to write explicit absent snapshots instead of fake `{"primary": "NA"}` selectors.
- Added cache summary health counts so reporting can distinguish active/absent/failure states without parsing selector values.
- Added regression coverage for same-domain concurrent selector discovery coordination and VoidCrawl tab isolation.
- Added smoke examples:
  - `examples/selector_discovery_race_smoke.py`
  - `examples/selector_cache_health_smoke.py`

## Cache Health Semantics

Cache health is deterministic Yosoi metadata, not something the LLM reasons about.

Current write behavior:
- Successful selector payloads are written as `status="active"`.
- Legacy `primary: "NA"` loads as `status="absent"` with selector fields cleared.
- Failed/absent field discovery is persisted as `status="absent"` with a reason.

The enum includes `discovery_failed` and `verification_failed` so cache files and reporting can represent those states explicitly, but this PR does not fully classify every failure mode into those finer states at write time. That can be a follow-up once we have a sharper distinction between true field absence, provider failure, and verifier rejection.

## Smoke Examples

Same-domain selector discovery race coordination:

```bash
uv run python examples/selector_discovery_race_smoke.py
```

Selector cache health states:

```bash
uv run python examples/selector_cache_health_smoke.py
```

Both examples are self-contained and do not require live network, browser automation, or LLM keys.

## GenAI Usage

- [x] AI-generated code was used in this PR

Used Codex to inspect the existing cache/discovery paths, implement scoped changes, add regression tests, and draft smoke examples. The changes were reviewed through focused tests and the repository CI check.

## Risks

- Existing cache compatibility is preserved for legacy `primary: "NA"` files.
- New cache writes no longer need fake selector sentinels for absent fields.
- Discovery coordination is process-local via `DiscoveryBus`; horizontal coordination across external workers/brokers remains out of scope.
- `discovery_failed` and `verification_failed` are available statuses but are not yet exhaustively assigned for every failure path.

## Testing

```bash
uv run python examples/selector_discovery_race_smoke.py
uv run python examples/selector_cache_health_smoke.py
uv run poe ci-check
```

Latest local `ci-check` passed:
- pre-hooks passed, including `ruff`, `vulture`, `mypy`, `uv-lock`, and secret checks
- `1933 passed`
- coverage `93.35%`

## Checklist

- [x] Branch is based on `main`
- [x] CI passes (lint, type check, tests)
- [x] Changes are focused - one logical change per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
