### PR TITLE
updated how stealth headers are used for Yosoi to VoidCrawl; added smoke

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ ini_options.testpaths = [ "tests" ]
 ini_options.asyncio_mode = "auto"
 ini_options.markers = [
   "eval: mark test as an evaluation test (requires real LLM and is slow)",
+  "smoke: mark test as an opt-in live smoke test",
 ]
 
 [tool.coverage]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -22,6 +22,7 @@ This project uses a **Tiered Testing Architecture** to balance speed, cost, and 
 | **1** | **Unit & Logic** | `tests/unit` | Verify schema validation and prompt construction. | **Deterministic** (`TestModel`) | Free |
 | **2** | **Simulated Integration** | `tests/integration` | Verify internal service coordination and I/O logic without real web traffic. | **Mocked** (`respx`, `mocker`) | Free |
 | **3** | **Quality Evals** | `tests/evals` | Verify the intelligence and accuracy of the AI on real-world data (not live web). | **Real** (Groq/Gemini) | $$$ |
+| **4** | **Live Smoke** | `tests/smoke` | Verify end-to-end browser wiring against selected live bot-check targets. | **None** | Network |
 
 ---
 
@@ -166,7 +167,8 @@ Tests are automatically marked based on their directory location in `tests/conft
 
 - `tests/unit/` → `@pytest.mark.unit`
 - `tests/integration/` → `@pytest.mark.integration`
-- `tests/evals/` → `@pytest.mark.evals`
+- `tests/evals/` → `@pytest.mark.eval`
+- `tests/smoke/` → `@pytest.mark.smoke`
 
 ## How to run
 
@@ -176,6 +178,7 @@ We use poe tasks from pyproject.toml for running tests. Ensure you are in the co
 uv run poe evals
 uv run poe integration
 uv run poe unit
+YOSOI_LIVE_SMOKE=1 uv run pytest -m smoke
 ```
 
 ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'integration: marks tests as integration tests')
     config.addinivalue_line('markers', 'unit: marks tests as unit tests')
     config.addinivalue_line('markers', 'eval: marks tests as evaluation tests')
+    config.addinivalue_line('markers', 'smoke: marks opt-in live smoke tests')
 
 
 def pytest_collection_modifyitems(config, items):
@@ -95,3 +96,5 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(pytest.mark.unit)
             elif 'evals' in parts:
                 item.add_marker(pytest.mark.eval)
+            elif 'smoke' in parts:
+                item.add_marker(pytest.mark.smoke)

--- a/tests/smoke/test_voidcrawl_live_sites.py
+++ b/tests/smoke/test_voidcrawl_live_sites.py
@@ -1,0 +1,39 @@
+"""Opt-in live smoke tests for Yosoi's VoidCrawl-backed bot-check wiring."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from yosoi.core.fetcher.voiddriver import _import_voidcrawl
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.skipif(
+        os.getenv('YOSOI_LIVE_SMOKE') != '1',
+        reason='set YOSOI_LIVE_SMOKE=1 to run live VoidCrawl smoke tests',
+    ),
+]
+
+
+BOTCHECK_URL = 'https://botcheck.com/'
+
+
+@pytest.mark.asyncio
+async def test_botcheck_renders_with_yosoi_voidcrawl_wiring() -> None:
+    BrowserPool, BrowserConfig, PoolConfig = _import_voidcrawl()
+    config = PoolConfig(
+        browsers=1,
+        tabs_per_browser=1,
+        browser=BrowserConfig(headless=False, stealth=True),
+    )
+
+    async with BrowserPool(config) as pool, pool.acquire() as tab:
+        await tab.goto(BOTCHECK_URL, timeout=60.0)
+        await tab.wait_for_network_idle(timeout=10.0)
+        html = (await tab.content()).lower()
+
+    assert 'bot' in html
+    assert 'challenge-platform' not in html
+    assert 'just a moment' not in html

--- a/tests/unit/core/fetcher/test_voiddriver_ua_policy.py
+++ b/tests/unit/core/fetcher/test_voiddriver_ua_policy.py
@@ -1,0 +1,59 @@
+"""Tests for VoidCrawl UA policy wiring."""
+
+from typing import ClassVar
+
+from yosoi.core.fetcher.voiddriver import HeadlessFetcher
+
+
+class BrowserConfigWithUa:
+    model_fields: ClassVar[dict[str, object]] = {
+        'headless': object(),
+        'stealth': object(),
+        'no_sandbox': object(),
+        'chrome_executable': object(),
+        'user_agent': object(),
+        'locale': object(),
+    }
+
+
+class BrowserConfigWithoutUa:
+    model_fields: ClassVar[dict[str, object]] = {
+        'headless': object(),
+        'stealth': object(),
+        'no_sandbox': object(),
+        'chrome_executable': object(),
+    }
+
+
+def test_browser_config_leaves_voidcrawl_identity_alone_by_default() -> None:
+    fetcher = HeadlessFetcher()
+
+    kwargs = fetcher._browser_config_kwargs(BrowserConfigWithUa)
+
+    assert 'user_agent' not in kwargs
+    assert 'locale' not in kwargs
+    assert kwargs['headless'] is True
+
+
+def test_browser_config_receives_explicit_yosoi_override_when_supported() -> None:
+    user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
+    fetcher = HeadlessFetcher(user_agent=user_agent, accept_language='en-US,en;q=0.9')
+
+    kwargs = fetcher._browser_config_kwargs(BrowserConfigWithUa)
+
+    assert kwargs['user_agent'] == user_agent
+    assert kwargs['locale'] == 'en-US,en;q=0.9'
+    assert kwargs['headless'] is True
+
+
+def test_browser_config_skips_identity_for_older_voidcrawl() -> None:
+    user_agent = (
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+        '(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
+    )
+    fetcher = HeadlessFetcher(user_agent=user_agent, accept_language='en-US,en;q=0.9')
+
+    kwargs = fetcher._browser_config_kwargs(BrowserConfigWithoutUa)
+
+    assert 'user_agent' not in kwargs
+    assert 'locale' not in kwargs

--- a/tests/unit/utils/test_headers.py
+++ b/tests/unit/utils/test_headers.py
@@ -26,6 +26,12 @@ class TestUserAgentRotator:
         """The UA pool contains multiple agents."""
         assert len(UserAgentRotator.USER_AGENTS) > 5
 
+    def test_get_chrome_is_recent_chrome(self):
+        """get_chrome returns a current Chrome UA."""
+        ua = UserAgentRotator.get_chrome()
+        assert 'Chrome/14' in ua
+        assert 'Edg' not in ua
+
 
 class TestHeaderGenerator:
     def test_generate_headers_has_required_keys(self):
@@ -43,7 +49,7 @@ class TestHeaderGenerator:
 
     def test_chrome_ua_gets_sec_fetch_headers(self):
         """Chrome user agent gets Sec-Fetch headers."""
-        chrome_ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0 Safari/537.36'
+        chrome_ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/148.0.0.0 Safari/537.36'
         headers = HeaderGenerator.generate_headers(user_agent=chrome_ua)
         assert 'Sec-Fetch-Dest' in headers
         assert headers['Sec-Fetch-Site'] == 'none'

--- a/yosoi/core/fetcher/simple.py
+++ b/yosoi/core/fetcher/simple.py
@@ -41,6 +41,7 @@ class SimpleFetcher(HTMLFetcher):
         min_delay: float = 0.5,
         max_delay: float = 2.0,
         randomize_headers: bool = True,
+        user_agent: str | None = None,
     ):
         """Intialize the simple fetcher.
 
@@ -51,6 +52,7 @@ class SimpleFetcher(HTMLFetcher):
             min_delay: Minimum time to pause between fetches
             max_delay: Maximum time to pause between fetches
             randomize_headers: If True then will randomize the headers used to fetch
+            user_agent: Fixed UA to use instead of per-request UA rotation
 
         """
         self.timeout = timeout
@@ -59,6 +61,7 @@ class SimpleFetcher(HTMLFetcher):
         self.min_delay = min_delay
         self.max_delay = max_delay
         self.randomize_headers = randomize_headers
+        self.user_agent = user_agent
 
         # Client is created lazily in __aenter__ when use_session=True
         self.client: httpx.AsyncClient | None = None
@@ -86,7 +89,7 @@ class SimpleFetcher(HTMLFetcher):
 
         """
         if self.randomize_headers:
-            user_agent = UserAgentRotator.get_random() if self.rotate_user_agent else None
+            user_agent = self.user_agent or (UserAgentRotator.get_random() if self.rotate_user_agent else None)
             return HeaderGenerator.generate_headers(user_agent=user_agent)
         # Fallback to static headers
         return {

--- a/yosoi/core/fetcher/voiddriver.py
+++ b/yosoi/core/fetcher/voiddriver.py
@@ -56,6 +56,8 @@ class _VoidCrawlFetcher(HTMLFetcher):
         browser_executable_path: str | None = None,
         console: Console | None = None,
         experimental_a3node: bool = False,
+        user_agent: str | None = None,
+        accept_language: str | None = None,
         **_kwargs: Any,
     ) -> None:
         self.timeout = timeout
@@ -65,6 +67,8 @@ class _VoidCrawlFetcher(HTMLFetcher):
         self.browser_executable_path = browser_executable_path
         self._console = console or Console()
         self._experimental_a3node = experimental_a3node
+        self._user_agent = user_agent
+        self._accept_language = accept_language
         self._pool: Any = None
         self._pool_ctx: Any = None
         self._a3node_storage = A3NodeStorage() if experimental_a3node else None
@@ -76,12 +80,7 @@ class _VoidCrawlFetcher(HTMLFetcher):
             browsers=1,
             tabs_per_browser=self.max_concurrent,
             tab_max_idle_secs=300,
-            browser=BrowserConfig(
-                headless=self._headless,
-                stealth=True,
-                no_sandbox=self.no_sandbox,
-                chrome_executable=self.browser_executable_path,
-            ),
+            browser=BrowserConfig(**self._browser_config_kwargs(BrowserConfig)),
         )
         self._pool_ctx = BrowserPool(config)
         self._pool = await self._pool_ctx.__aenter__()
@@ -93,6 +92,25 @@ class _VoidCrawlFetcher(HTMLFetcher):
             self._console.print('[dim]  ↻ A3Node cache disabled — running DOMLoader fresh[/dim]')
             logger.info('VoidCrawl fetcher ready (A3Node disabled)')
         return self
+
+    def _browser_config_kwargs(self, BrowserConfig: Any) -> dict[str, Any]:
+        """Build BrowserConfig kwargs, only overriding UA when requested."""
+        kwargs: dict[str, Any] = {
+            'headless': self._headless,
+            'stealth': True,
+            'no_sandbox': self.no_sandbox,
+            'chrome_executable': self.browser_executable_path,
+        }
+        fields = getattr(BrowserConfig, 'model_fields', None)
+        if fields is None:
+            fields = getattr(BrowserConfig, '__fields__', {})
+        if self._user_agent is not None and 'user_agent' in fields:
+            kwargs['user_agent'] = self._user_agent
+        if self._accept_language is not None and 'locale' in fields:
+            kwargs['locale'] = self._accept_language
+        elif self._accept_language is not None and 'accept_language' in fields:
+            kwargs['accept_language'] = self._accept_language
+        return kwargs
 
     async def __aexit__(self, *exc: Any) -> None:
         if self._pool is not None:

--- a/yosoi/core/fetcher/waterfall.py
+++ b/yosoi/core/fetcher/waterfall.py
@@ -66,6 +66,8 @@ class JSFetcher(HTMLFetcher):
         console: Console | None = None,
         force: bool = False,
         experimental_a3node: bool = False,
+        voidcrawl_user_agent: str | None = None,
+        voidcrawl_accept_language: str | None = None,
     ):
         """Initialise the three-tier JS fetcher.
 
@@ -83,6 +85,9 @@ class JSFetcher(HTMLFetcher):
             force: Skip fetcher strategy cache and re-run full waterfall. Defaults to False.
             experimental_a3node: Opt into experimental A3Node persistence/replay.
                 Disabled by default so browser rendering always uses a fresh DOMLoader run.
+            voidcrawl_user_agent: Optional browser UA override. When omitted,
+                VoidCrawl owns UA and matching Client Hints.
+            voidcrawl_accept_language: Optional browser Accept-Language override.
 
         """
         self._simple = SimpleFetcher(
@@ -113,6 +118,8 @@ class JSFetcher(HTMLFetcher):
             'browser_executable_path': browser_executable_path,
             'console': self._console,
             'experimental_a3node': experimental_a3node,
+            'user_agent': voidcrawl_user_agent,
+            'accept_language': voidcrawl_accept_language,
         }
 
     # ------------------------------------------------------------------

--- a/yosoi/utils/headers.py
+++ b/yosoi/utils/headers.py
@@ -15,27 +15,24 @@ class UserAgentRotator:
 
     """
 
-    # Pool of realistic, recent user agents
+    # Pool for Yosoi's plain HTTP fetcher. Browser-side UA, platform,
+    # and Client Hints are owned by VoidCrawl unless Yosoi explicitly
+    # passes a UA override into the VoidCrawl-backed fetcher.
     USER_AGENTS: ClassVar[tuple[str, ...]] = (
         # Chrome on Windows
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36',
         # Chrome on Mac
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
-        # Firefox on Windows
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0',
-        # Firefox on Mac
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0',
-        # Safari on Mac
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
-        # Edge on Windows
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36',
         # Chrome on Linux
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36',
+        # Edge on Windows
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0',
+        # Firefox
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:142.0) Gecko/20100101 Firefox/142.0',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:142.0) Gecko/20100101 Firefox/142.0',
     )
 
     @classmethod
@@ -47,6 +44,12 @@ class UserAgentRotator:
 
         """
         return random.choice(cls.USER_AGENTS)
+
+    @classmethod
+    def get_chrome(cls) -> str:
+        """Get a Chrome UA for browser-backed fetching."""
+        chrome = [ua for ua in cls.USER_AGENTS if 'Chrome' in ua and 'Edg' not in ua]
+        return random.choice(chrome)
 
     @classmethod
     def get_chrome_windows(cls) -> str:
@@ -75,7 +78,10 @@ class HeaderGenerator:
     """Generates realistic browser headers with variation."""
 
     @staticmethod
-    def generate_headers(user_agent: str | None = None, referer: str | None = None) -> dict[str, str]:
+    def generate_headers(
+        user_agent: str | None = None,
+        referer: str | None = None,
+    ) -> dict[str, str]:
         """Generate realistic browser headers with randomization.
 
         Args:
@@ -89,26 +95,18 @@ class HeaderGenerator:
         if user_agent is None:
             user_agent = UserAgentRotator.get_random()
 
-        languages = [
-            'en-US,en;q=0.9',
-            'en-GB,en;q=0.9',
-            'en-US,en;q=0.9,es;q=0.8',
-            'en-US,en;q=0.9,fr;q=0.8',
-            'en-US,en;q=0.5',
-        ]
-
         # Base headers that all browsers send
         headers = {
             'User-Agent': user_agent,
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
-            'Accept-Language': random.choice(languages),
+            'Accept-Language': 'en-US,en;q=0.9',
             'Accept-Encoding': 'gzip, deflate, br',
             'DNT': '1',
             'Connection': 'keep-alive',
             'Upgrade-Insecure-Requests': '1',
         }
 
-        # Add Sec-Fetch-* headers (Chrome/Edge specific)
+        # Add Sec-Fetch-* headers (Chrome/Edge specific).
         if 'Chrome' in user_agent or 'Edg' in user_agent:
             headers.update(
                 {


### PR DESCRIPTION
Linear: CAS-65

## Intent

Unify Yosoi's UA policy with VoidCrawl without duplicating VoidCrawl's browser fingerprint logic. By default, VoidCrawl continues to own browser UA, platform, and Client Hints derivation; Yosoi only passes an explicit browser override when requested.

## Changes

- Refreshes Yosoi's HTTP `UserAgentRotator` pool from Chrome 119-121-era strings to current Chrome 147/148-era strings, with updated Firefox and Edge entries.
- Adds a fixed `user_agent` option to `SimpleFetcher` for callers that need a stable HTTP identity.
- Adds optional `voidcrawl_user_agent` and `voidcrawl_accept_language` wiring through `JSFetcher` into the VoidCrawl-backed fetchers.
- Updates `HeadlessFetcher` / `HeadfulFetcher` to pass `user_agent` / locale into VoidCrawl only when those fields exist on the installed `BrowserConfig`.
- Adds unit coverage for the default policy: no browser UA override is sent unless explicitly configured.
- Adds an opt-in live smoke tier for bot-check wiring using `botcheck.com`.

## GenAI Usage

- [x] AI-generated code was used in this PR

AI assistance was used to inspect the fetcher/headers code, implement the scoped wiring and tests, and iterate on the live smoke coverage. Changes were reviewed and verified locally.

## Risks

- The browser-side override depends on a newer VoidCrawl Python `BrowserConfig` surface. Older VoidCrawl versions are handled by skipping unsupported fields, so the default remains compatible but explicit overrides will be inert until the fields exist.
- The live smoke test uses VoidCrawl's lower-level tab API through Yosoi's import path because Yosoi's one-shot fetcher wrapper does not yet expose a first-class "navigate, wait/click/fill, then capture" workflow hook.

## Testing

- `uv run ruff check yosoi/utils/headers.py yosoi/core/fetcher/simple.py yosoi/core/fetcher/waterfall.py yosoi/core/fetcher/voiddriver.py tests/unit/utils/test_headers.py tests/unit/core/fetcher/test_voiddriver_ua_policy.py tests/smoke/test_voidcrawl_live_sites.py tests/conftest.py`
- `uv run pytest tests/unit/utils/test_headers.py tests/unit/core/fetcher/test_simple.py tests/unit/core/fetcher/test_voiddriver_ua_policy.py tests/unit/core/fetcher/test_waterfall.py tests/smoke/test_voidcrawl_live_sites.py -q`
  - `40 passed, 1 skipped, 1 warning`
- `YOSOI_LIVE_SMOKE=1 uv run pytest -m smoke -q`
  - `1 passed, 1942 deselected, 1 warning`

## Checklist

- [x] Branch is based on `main`
- [x] CI passes locally for focused lint/tests
- [x] Changes are focused - one logical change per PR
