### PR TITLE
feat(sinks): pluggable append-only content sink (sqlite/postgres/mongo) [CAS-74]

### DIFF
--- a/docker-compose.sinks.yml
+++ b/docker-compose.sinks.yml
@@ -1,0 +1,50 @@
+# Local Postgres + MongoDB for developing and testing yosoi content sinks.
+#
+#   docker compose -f docker-compose.sinks.yml up -d
+#
+# Then point the sink integration tests at the running stack (otherwise they
+# fall back to ephemeral testcontainers, which is slower per run):
+#
+#   export YOSOI_TEST_POSTGRES_DSN='postgresql://yosoi:yosoi@localhost:5433/yosoi'
+#   export YOSOI_TEST_MONGO_URI='mongodb://localhost:27018'
+#   uv run pytest tests/integration/sinks/
+#
+# Host ports default to non-default values (5433 / 27018) to avoid clashing with
+# a local Postgres/Mongo install or the docker-compose.langfuse.yml stack. If
+# those are taken too, override them (and the DSNs above to match):
+#   YOSOI_PG_PORT=5455 YOSOI_MONGO_PORT=27044 docker compose -f docker-compose.sinks.yml up -d
+# Credentials below are dev-only — do NOT deploy as-is.
+services:
+  sinks-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: yosoi
+      POSTGRES_PASSWORD: yosoi # CHANGEME for anything but local dev
+      POSTGRES_DB: yosoi
+    ports:
+      - "${YOSOI_PG_PORT:-5433}:5432"
+    volumes:
+      - sinks-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U yosoi -d yosoi"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  sinks-mongo:
+    image: mongo:7
+    restart: unless-stopped
+    ports:
+      - "${YOSOI_MONGO_PORT:-27018}:27017"
+    volumes:
+      - sinks-mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  sinks-postgres-data:
+  sinks-mongo-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
   "tenacity>=9.1.4",
   "voidcrawl>=0.3.2",
 ]
+optional-dependencies.psycopg = [ "psycopg[binary]>=3.2" ]
+optional-dependencies.pymongo = [ "pymongo>=4.9" ]
 optional-dependencies.tabular = [ "openpyxl>=3.1", "pandas>=2", "pyarrow>=14" ]
 urls.Changelog = "https://github.com/CascadingLabs/Yosoi/blob/main/CHANGELOG.md"
 urls.Homepage = "https://cascadinglabs.com/yosoi/"
@@ -79,7 +81,9 @@ tests = [
   "pandas>=2",
   "poethepoet>=0.42",
   "polyfactory>=3.3",
+  "psycopg[binary]>=3.2",
   "pyarrow>=14",
+  "pymongo>=4.9",
   "pytest>=9.0.2",
   "pytest-asyncio>=1.3",
   "pytest-cov>=7.1",
@@ -199,6 +203,8 @@ run.omit = [
   "yosoi/core/fetcher/dom/tree/*",
   "yosoi/core/fetcher/voiddriver.py",
   "yosoi/core/fetcher/waterfall.py",
+  "yosoi/sinks/mongo.py",
+  "yosoi/sinks/postgres.py",
 ]
 run.source = [ "yosoi" ]
 report.exclude_lines = [

--- a/tests/integration/sinks/test_mongo_integration.py
+++ b/tests/integration/sinks/test_mongo_integration.py
@@ -1,0 +1,43 @@
+"""Integration round-trip for MongoSink against a real MongoDB container.
+
+Requires Docker. Skips cleanly when Docker (or the testcontainers/pymongo deps)
+are unavailable, so it never breaks a laptop or container-less CI run.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip('pymongo', reason='pymongo not installed — run: uv add yosoi[pymongo]')
+testcontainers_mongodb = pytest.importorskip('testcontainers.mongodb', reason='testcontainers not installed')
+
+from yosoi.sinks import ContentRecord, MongoSink
+
+BASE = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope='module')
+def mongo_uri():
+    try:
+        with testcontainers_mongodb.MongoDbContainer('mongo:7') as mongo:
+            yield mongo.get_connection_url()
+    except Exception as exc:  # noqa: BLE001 - Docker not available / pull failed
+        pytest.skip(f'MongoDB container unavailable: {exc}')
+
+
+async def test_mongo_roundtrip_by_url_and_time(mongo_uri):
+    async with MongoSink(mongo_uri, database='yosoi_it', collection='content') as sink:
+        await sink.write(ContentRecord(url='https://x.com/a', content={'v': 1}, scraped_at=BASE, source='it'))
+        await sink.write(
+            ContentRecord(url='https://x.com/a', content={'v': 2}, scraped_at=BASE + timedelta(hours=1), source='it')
+        )
+        await sink.write(
+            ContentRecord(url='https://x.com/b', content=[{'k': 1}], scraped_at=BASE + timedelta(days=3), source='it')
+        )
+
+        by_url = await sink.read_by_url('https://x.com/a')
+        assert [r.content['v'] for r in by_url] == [2, 1]  # append-only, newest-first
+
+        by_time = await sink.read_by_time(BASE + timedelta(days=1))
+        assert [r.url for r in by_time] == ['https://x.com/b']
+        assert by_time[0].content == [{'k': 1}]

--- a/tests/integration/sinks/test_mongo_integration.py
+++ b/tests/integration/sinks/test_mongo_integration.py
@@ -1,15 +1,21 @@
-"""Integration round-trip for MongoSink against a real MongoDB container.
+"""Integration round-trip for MongoSink against a real MongoDB.
 
-Requires Docker. Skips cleanly when Docker (or the testcontainers/pymongo deps)
-are unavailable, so it never breaks a laptop or container-less CI run.
+Prefers an already-running instance via ``YOSOI_TEST_MONGO_URI`` (e.g. the
+``docker-compose.sinks.yml`` stack); otherwise spins up an ephemeral
+testcontainers instance. Skips cleanly when neither a URI nor Docker is
+available, so it never breaks a laptop or container-less CI run.
+
+Each test uses a unique database and drops it afterwards, so runs stay isolated
+and idempotent even against the persistent compose stack.
 """
 
+import os
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
 
 pytest.importorskip('pymongo', reason='pymongo not installed — run: uv add yosoi[pymongo]')
-testcontainers_mongodb = pytest.importorskip('testcontainers.mongodb', reason='testcontainers not installed')
 
 from yosoi.sinks import ContentRecord, MongoSink
 
@@ -18,26 +24,46 @@ BASE = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 @pytest.fixture(scope='module')
 def mongo_uri():
+    uri = os.getenv('YOSOI_TEST_MONGO_URI')
+    if uri:
+        yield uri
+        return
+    testcontainers_mongodb = pytest.importorskip('testcontainers.mongodb', reason='testcontainers not installed')
     try:
         with testcontainers_mongodb.MongoDbContainer('mongo:7') as mongo:
             yield mongo.get_connection_url()
     except Exception as exc:  # noqa: BLE001 - Docker not available / pull failed
-        pytest.skip(f'MongoDB container unavailable: {exc}')
+        pytest.skip(f'MongoDB unavailable: set YOSOI_TEST_MONGO_URI or start Docker ({exc})')
 
 
-async def test_mongo_roundtrip_by_url_and_time(mongo_uri):
-    async with MongoSink(mongo_uri, database='yosoi_it', collection='content') as sink:
-        await sink.write(ContentRecord(url='https://x.com/a', content={'v': 1}, scraped_at=BASE, source='it'))
-        await sink.write(
-            ContentRecord(url='https://x.com/a', content={'v': 2}, scraped_at=BASE + timedelta(hours=1), source='it')
-        )
-        await sink.write(
-            ContentRecord(url='https://x.com/b', content=[{'k': 1}], scraped_at=BASE + timedelta(days=3), source='it')
-        )
+@pytest.fixture
+async def sink(mongo_uri):
+    db_name = f'yosoi_it_{uuid.uuid4().hex}'
+    try:
+        async with MongoSink(mongo_uri, database=db_name, collection='content') as sink:
+            yield sink
+    finally:
+        from pymongo import AsyncMongoClient
 
-        by_url = await sink.read_by_url('https://x.com/a')
-        assert [r.content['v'] for r in by_url] == [2, 1]  # append-only, newest-first
+        client: AsyncMongoClient = AsyncMongoClient(mongo_uri)
+        try:
+            await client.drop_database(db_name)
+        finally:
+            await client.close()
 
-        by_time = await sink.read_by_time(BASE + timedelta(days=1))
-        assert [r.url for r in by_time] == ['https://x.com/b']
-        assert by_time[0].content == [{'k': 1}]
+
+async def test_mongo_roundtrip_by_url_and_time(sink):
+    await sink.write(ContentRecord(url='https://x.com/a', content={'v': 1}, scraped_at=BASE, source='it'))
+    await sink.write(
+        ContentRecord(url='https://x.com/a', content={'v': 2}, scraped_at=BASE + timedelta(hours=1), source='it')
+    )
+    await sink.write(
+        ContentRecord(url='https://x.com/b', content=[{'k': 1}], scraped_at=BASE + timedelta(days=3), source='it')
+    )
+
+    by_url = await sink.read_by_url('https://x.com/a')
+    assert [r.content['v'] for r in by_url] == [2, 1]  # append-only, newest-first
+
+    by_time = await sink.read_by_time(BASE + timedelta(days=1))
+    assert [r.url for r in by_time] == ['https://x.com/b']
+    assert by_time[0].content == [{'k': 1}]

--- a/tests/integration/sinks/test_postgres_integration.py
+++ b/tests/integration/sinks/test_postgres_integration.py
@@ -1,0 +1,43 @@
+"""Integration round-trip for PostgresSink against a real Postgres container.
+
+Requires Docker. Skips cleanly when Docker (or the testcontainers/psycopg deps)
+are unavailable, so it never breaks a laptop or container-less CI run.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip('psycopg', reason='psycopg not installed — run: uv add yosoi[psycopg]')
+testcontainers_postgres = pytest.importorskip('testcontainers.postgres', reason='testcontainers not installed')
+
+from yosoi.sinks import ContentRecord, PostgresSink
+
+BASE = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope='module')
+def conninfo():
+    try:
+        with testcontainers_postgres.PostgresContainer('postgres:16-alpine') as pg:
+            yield pg.get_connection_url(driver=None)
+    except Exception as exc:  # noqa: BLE001 - Docker not available / pull failed
+        pytest.skip(f'Postgres container unavailable: {exc}')
+
+
+async def test_postgres_roundtrip_by_url_and_time(conninfo):
+    async with PostgresSink(conninfo) as sink:
+        await sink.write(ContentRecord(url='https://x.com/a', content={'v': 1}, scraped_at=BASE, source='it'))
+        await sink.write(
+            ContentRecord(url='https://x.com/a', content={'v': 2}, scraped_at=BASE + timedelta(hours=1), source='it')
+        )
+        await sink.write(
+            ContentRecord(url='https://x.com/b', content=[{'k': 1}], scraped_at=BASE + timedelta(days=3), source='it')
+        )
+
+        by_url = await sink.read_by_url('https://x.com/a')
+        assert [r.content['v'] for r in by_url] == [2, 1]  # append-only, newest-first
+
+        by_time = await sink.read_by_time(BASE + timedelta(days=1))
+        assert [r.url for r in by_time] == ['https://x.com/b']
+        assert by_time[0].content == [{'k': 1}]

--- a/tests/integration/sinks/test_postgres_integration.py
+++ b/tests/integration/sinks/test_postgres_integration.py
@@ -1,15 +1,21 @@
-"""Integration round-trip for PostgresSink against a real Postgres container.
+"""Integration round-trip for PostgresSink against a real Postgres.
 
-Requires Docker. Skips cleanly when Docker (or the testcontainers/psycopg deps)
-are unavailable, so it never breaks a laptop or container-less CI run.
+Prefers an already-running instance via ``YOSOI_TEST_POSTGRES_DSN`` (e.g. the
+``docker-compose.sinks.yml`` stack); otherwise spins up an ephemeral
+testcontainers instance. Skips cleanly when neither a DSN nor Docker is
+available, so it never breaks a laptop or container-less CI run.
+
+Each test uses a unique table and drops it afterwards, so runs stay isolated
+and idempotent even against the persistent compose stack.
 """
 
+import os
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
 
 pytest.importorskip('psycopg', reason='psycopg not installed — run: uv add yosoi[psycopg]')
-testcontainers_postgres = pytest.importorskip('testcontainers.postgres', reason='testcontainers not installed')
 
 from yosoi.sinks import ContentRecord, PostgresSink
 
@@ -18,26 +24,43 @@ BASE = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 @pytest.fixture(scope='module')
 def conninfo():
+    dsn = os.getenv('YOSOI_TEST_POSTGRES_DSN')
+    if dsn:
+        yield dsn
+        return
+    testcontainers_postgres = pytest.importorskip('testcontainers.postgres', reason='testcontainers not installed')
     try:
         with testcontainers_postgres.PostgresContainer('postgres:16-alpine') as pg:
             yield pg.get_connection_url(driver=None)
     except Exception as exc:  # noqa: BLE001 - Docker not available / pull failed
-        pytest.skip(f'Postgres container unavailable: {exc}')
+        pytest.skip(f'Postgres unavailable: set YOSOI_TEST_POSTGRES_DSN or start Docker ({exc})')
 
 
-async def test_postgres_roundtrip_by_url_and_time(conninfo):
-    async with PostgresSink(conninfo) as sink:
-        await sink.write(ContentRecord(url='https://x.com/a', content={'v': 1}, scraped_at=BASE, source='it'))
-        await sink.write(
-            ContentRecord(url='https://x.com/a', content={'v': 2}, scraped_at=BASE + timedelta(hours=1), source='it')
-        )
-        await sink.write(
-            ContentRecord(url='https://x.com/b', content=[{'k': 1}], scraped_at=BASE + timedelta(days=3), source='it')
-        )
+@pytest.fixture
+async def sink(conninfo):
+    table = f'content_test_{uuid.uuid4().hex}'  # uuid hex is a safe SQL identifier
+    try:
+        async with PostgresSink(conninfo, table=table) as sink:
+            yield sink
+    finally:
+        import psycopg
 
-        by_url = await sink.read_by_url('https://x.com/a')
-        assert [r.content['v'] for r in by_url] == [2, 1]  # append-only, newest-first
+        async with await psycopg.AsyncConnection.connect(conninfo, autocommit=True) as cleanup:
+            await cleanup.execute(f'DROP TABLE IF EXISTS {table}')
 
-        by_time = await sink.read_by_time(BASE + timedelta(days=1))
-        assert [r.url for r in by_time] == ['https://x.com/b']
-        assert by_time[0].content == [{'k': 1}]
+
+async def test_postgres_roundtrip_by_url_and_time(sink):
+    await sink.write(ContentRecord(url='https://x.com/a', content={'v': 1}, scraped_at=BASE, source='it'))
+    await sink.write(
+        ContentRecord(url='https://x.com/a', content={'v': 2}, scraped_at=BASE + timedelta(hours=1), source='it')
+    )
+    await sink.write(
+        ContentRecord(url='https://x.com/b', content=[{'k': 1}], scraped_at=BASE + timedelta(days=3), source='it')
+    )
+
+    by_url = await sink.read_by_url('https://x.com/a')
+    assert [r.content['v'] for r in by_url] == [2, 1]  # append-only, newest-first
+
+    by_time = await sink.read_by_time(BASE + timedelta(days=1))
+    assert [r.url for r in by_time] == ['https://x.com/b']
+    assert by_time[0].content == [{'k': 1}]

--- a/tests/unit/sinks/test_lazy_import.py
+++ b/tests/unit/sinks/test_lazy_import.py
@@ -1,0 +1,35 @@
+"""Lazy-import behaviour and Protocol conformance for the sink backends.
+
+Drivers are optional extras. A missing driver must surface a helpful
+``install yosoi[...]`` message, not a raw ImportError, and only when the backend
+is actually constructed — importing the module must stay driver-free.
+"""
+
+import sys
+
+import pytest
+
+from yosoi.sinks import ContentSink, MongoSink, PostgresSink, SqliteSink
+from yosoi.sinks._internal import MissingSinkDependencyError
+
+
+def test_sqlite_satisfies_content_sink_protocol():
+    assert isinstance(SqliteSink(':memory:'), ContentSink)
+
+
+def test_postgres_missing_driver_gives_helpful_message(monkeypatch):
+    # Setting the module to None makes `import psycopg` raise ImportError.
+    monkeypatch.setitem(sys.modules, 'psycopg', None)
+    with pytest.raises(MissingSinkDependencyError, match=r'yosoi\[psycopg\]'):
+        PostgresSink('postgresql://localhost/db')
+
+
+def test_mongo_missing_driver_gives_helpful_message(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'pymongo', None)
+    with pytest.raises(MissingSinkDependencyError, match=r'yosoi\[pymongo\]'):
+        MongoSink('mongodb://localhost:27017')
+
+
+def test_missing_dependency_error_is_an_import_error():
+    # Existing `except ImportError` handlers keep working.
+    assert issubclass(MissingSinkDependencyError, ImportError)

--- a/tests/unit/sinks/test_record.py
+++ b/tests/unit/sinks/test_record.py
@@ -1,0 +1,28 @@
+"""Unit tests for the ContentRecord contract."""
+
+from datetime import datetime, timezone
+
+from yosoi.sinks import ContentRecord
+
+
+def test_defaults_scraped_at_to_utc_now():
+    rec = ContentRecord(url='https://example.com', content={'title': 'Hi'}, source='unit')
+    assert rec.scraped_at.tzinfo is not None
+    assert rec.scraped_at.utcoffset() == timezone.utc.utcoffset(None)
+
+
+def test_accepts_dict_content():
+    rec = ContentRecord(url='https://example.com', content={'title': 'Hi', 'price': 9.99}, source='unit')
+    assert rec.content == {'title': 'Hi', 'price': 9.99}
+
+
+def test_accepts_list_content_for_multi_item_pages():
+    items = [{'title': 'A'}, {'title': 'B'}]
+    rec = ContentRecord(url='https://example.com', content=items, source='unit')
+    assert rec.content == items
+
+
+def test_preserves_explicit_scraped_at():
+    when = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    rec = ContentRecord(url='https://example.com', content={}, scraped_at=when, source='unit')
+    assert rec.scraped_at == when

--- a/tests/unit/sinks/test_sqlite.py
+++ b/tests/unit/sinks/test_sqlite.py
@@ -1,0 +1,88 @@
+"""Unit tests for SqliteSink — full round-trip against a real (stdlib) SQLite file."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from yosoi.sinks import ContentRecord, SqliteSink
+
+BASE = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def sink(tmp_path):
+    return SqliteSink(tmp_path / 'content.db')
+
+
+async def test_write_then_read_by_url(sink):
+    rec = ContentRecord(url='https://x.com/a', content={'title': 'Hello'}, scraped_at=BASE, source='unit')
+    await sink.write(rec)
+
+    got = await sink.read_by_url('https://x.com/a')
+    assert len(got) == 1
+    assert got[0].url == 'https://x.com/a'
+    assert got[0].content == {'title': 'Hello'}
+    assert got[0].scraped_at == BASE
+    assert got[0].source == 'unit'
+
+
+async def test_append_only_keeps_every_version_newest_first(sink):
+    older = ContentRecord(url='https://x.com/a', content={'v': 1}, scraped_at=BASE, source='unit')
+    newer = ContentRecord(url='https://x.com/a', content={'v': 2}, scraped_at=BASE + timedelta(hours=1), source='unit')
+    await sink.write(older)
+    await sink.write(newer)
+
+    got = await sink.read_by_url('https://x.com/a')
+    assert [r.content['v'] for r in got] == [2, 1]  # newest first, nothing overwritten
+
+
+async def test_read_by_url_isolates_urls(sink):
+    await sink.write(ContentRecord(url='https://x.com/a', content={}, scraped_at=BASE, source='unit'))
+    await sink.write(ContentRecord(url='https://x.com/b', content={}, scraped_at=BASE, source='unit'))
+
+    assert len(await sink.read_by_url('https://x.com/a')) == 1
+    assert await sink.read_by_url('https://x.com/missing') == []
+
+
+async def test_read_by_time_inclusive_range(sink):
+    for i in range(4):
+        await sink.write(
+            ContentRecord(
+                url=f'https://x.com/{i}', content={'i': i}, scraped_at=BASE + timedelta(days=i), source='unit'
+            )
+        )
+
+    got = await sink.read_by_time(BASE + timedelta(days=1), BASE + timedelta(days=2))
+    assert sorted(r.content['i'] for r in got) == [1, 2]
+
+
+async def test_read_by_time_open_ended(sink):
+    await sink.write(ContentRecord(url='https://x.com/old', content={}, scraped_at=BASE, source='unit'))
+    await sink.write(
+        ContentRecord(url='https://x.com/new', content={}, scraped_at=BASE + timedelta(days=10), source='unit')
+    )
+
+    got = await sink.read_by_time(BASE + timedelta(days=5))
+    assert [r.url for r in got] == ['https://x.com/new']
+
+
+async def test_naive_datetime_treated_as_utc(sink):
+    naive = datetime(2026, 5, 1, 12, 0, 0)  # no tzinfo
+    await sink.write(ContentRecord(url='https://x.com/a', content={}, scraped_at=naive, source='unit'))
+
+    got = await sink.read_by_time(BASE - timedelta(minutes=1), BASE + timedelta(minutes=1))
+    assert len(got) == 1
+
+
+async def test_list_content_roundtrips(sink):
+    items = [{'title': 'A'}, {'title': 'B'}]
+    await sink.write(ContentRecord(url='https://x.com/list', content=items, scraped_at=BASE, source='unit'))
+
+    got = await sink.read_by_url('https://x.com/list')
+    assert got[0].content == items
+
+
+async def test_usable_as_async_context_manager(tmp_path):
+    async with SqliteSink(tmp_path / 'cm.db') as sink:
+        await sink.write(ContentRecord(url='https://x.com/a', content={}, scraped_at=BASE, source='unit'))
+        assert len(await sink.read_by_url('https://x.com/a')) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -892,6 +892,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3086,6 +3095,86 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/bf/70d8a60488f9955cbbcd538beae44d56bb2f1d19e673b72788f2d343ff55/psycopg_binary-3.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b7bfff1ca23732b488cbca3076fc11bc98d520ee122514fdb17a8e20d3338f5a", size = 4609750, upload-time = "2026-05-01T23:24:20.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b0/29e98ba210c9dbc75a6dc91e3f99b9e06ea901a62ca95804e02a1ae13e6b/psycopg_binary-3.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32a6fbf8481e3a370d0d72b860d35948a693cb01281da217f7b2f307636e591a", size = 4676700, upload-time = "2026-05-01T23:25:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ab/3df087b3c12bf74e47c08204172b2fabb5a144679110d5c7ad12d9201323/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bdef84570ebbce1d42b4e7ea952d21c414c5f118ad02fee00c5625f35e134429", size = 5496319, upload-time = "2026-05-01T23:25:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/f088207b4cd6772f9e0d8a91807e79fa2458d4eb9eb1ae406c68415f2bec/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbc10768a796c96d3243656016bf4e337c81c71097270bb7b0ad6210d9765", size = 5171906, upload-time = "2026-05-01T23:25:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/4523a857f253871d75c22e1c2e79fd47e599e736bcba1bad58d83e24be02/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf7f73a4a792bc5db58a4b385d8a1467e8d468f7548702fb0ed1e9b7501b1c13", size = 6762621, upload-time = "2026-05-01T23:25:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d1/925bf776503345bef428e6c45fb017d0139ddbe0e211814b585c4253dca8/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7b4d40c153fa352ab3cca530f3a0baedf7621b2ebcbd7f084009522c21788fc", size = 5006319, upload-time = "2026-05-01T23:25:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/aa/99727337206fbba357ca084bf4ea8b29dc986f61842a2685859af61416db/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f9b1c2533af01cd7648378599f82b0b8ae32f293296e6eec5753a625bc97ef28", size = 4535388, upload-time = "2026-05-01T23:25:57.957Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a4/567ba2c37d19d8c2f63d836385dfd2495aa5897bbee6cfab104d9ee58624/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad3bc94054876155549fdaedf4a46d1ec69d39a5bcee377148afe498e84c4b8e", size = 4224544, upload-time = "2026-05-01T23:26:03.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/23/86457f5a82731685d7701de7bfaa5eb783dd1fecbf875321897d9d9ce33a/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eb4eed2079c01a4850bf467deacfab56d356d4225040170af03dc9958321242d", size = 3956282, upload-time = "2026-05-01T23:26:09.983Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/249456df16d47de082abd9b73bce8ccdeb0293eb12e590f9150c7cbdb788/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f80e3f2b5331dbbf0901bcb658056c03eeb2c1ef31d774afb0d61598b242e744", size = 4261736, upload-time = "2026-05-01T23:26:16.798Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/c4abe228acafd8a385c1fb615d4f1e3c9b8ad7a4e4f0e84118ba3ffeed9c/psycopg_binary-3.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:574ea21a9651958f1535c5a1c649c7409e9168bcbffa29a3f2f961f58b322949", size = 3570620, upload-time = "2026-05-01T23:26:22.655Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3429,6 +3518,77 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/64/50be6fbac9c79fe2e4c17401a467da2d8764d82833d83cec325afe5cab32/pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0", size = 2523370, upload-time = "2026-04-20T16:39:53.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/77/28ebbf69772a4341d530831c7a006cdb06877ac23075cb53b0a227df4fe1/pymongo-4.17.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:47b021363cd923ace5edc7a1d63c0ff8a6d9d43859b8a1ba23645f5afae63221", size = 819234, upload-time = "2026-04-20T16:37:20.888Z" },
+    { url = "https://files.pythonhosted.org/packages/88/cf/5a70cee503ff9a2fea20607607f14d189f4d975960ac0945ec306ee7b695/pymongo-4.17.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:422fa50d7d7f5c22ea0953554396c9ef95684a2d775f860bd75a7b510538dfca", size = 819969, upload-time = "2026-04-20T16:37:24.187Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d5/07b7e27e662c58d872efd104a0e8055eb6569aa1b6d4da436f3fdee7f897/pymongo-4.17.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:addd0498ebbdc6354227f6ed457ed9fce442d48a3bb30d5b5bad33e104996561", size = 1244510, upload-time = "2026-04-20T16:37:26.069Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/7cac5b1e89bd5a8e395067648241390321593a7c29243e36f91343c02a90/pymongo-4.17.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5c8e180cb2cabe37300e1e36c60aa4f2ff956cc579f0142135a5d2cba252243", size = 1263245, upload-time = "2026-04-20T16:37:28.003Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/40e8e99824c1fda18261411e65ce3b0cd3d9a6ed3c056cdd0a569adc870b/pymongo-4.17.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bd835cdb37a1adec359dd072c24f8bb14809e2644fde86fab4ee2fc9719b9483", size = 1304113, upload-time = "2026-04-20T16:37:30.048Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/94/fb7e25441dd66f2069a9b172380849b0eaa5881c18b3db217bf64a6d393c/pymongo-4.17.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4979e7e8887862bbb44d203f00cc8263a3f27237876fa691b6beba23e40e6d8", size = 1297046, upload-time = "2026-04-20T16:37:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c9/7352e0c20fe772541556e4d283c05e07ec48f8b0d2737ad930ac4a1b6655/pymongo-4.17.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:77aa4bc164b4de60d5db193b322f0f5b6ead716e831031bfdef8e8bd92205556", size = 1265708, upload-time = "2026-04-20T16:37:33.934Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e4/3df15494c2015ed297958517f0e4f6493e21b00990748068a973e66d45e0/pymongo-4.17.0-cp310-cp310-win32.whl", hash = "sha256:48bbc576677b50af043df870d84ded67cc3a9b4aa7553201beef4da5dc050a0a", size = 805533, upload-time = "2026-04-20T16:37:35.744Z" },
+    { url = "https://files.pythonhosted.org/packages/22/fa/b4e71bb8cb82ad7d21bb4e8c476f2d573ba68b20368aac36ef06e4a196b4/pymongo-4.17.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46767f28dea610e02edf6c5d956ce615c3c7790ea396660b9b1efd5c5ead2e0", size = 815677, upload-time = "2026-04-20T16:37:37.808Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e2/0a4bba644f1cda3970ea1012149eeae3594ebfeed3f81fdaf32b61d90c95/pymongo-4.17.0-cp310-cp310-win_arm64.whl", hash = "sha256:757f2a4c0c2c46cab87df0333681ce69e86c9d5b45bc5203ceba5410b3489e59", size = 807293, upload-time = "2026-04-20T16:37:39.707Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e2/336d86f221cf1b56b2ed9330d4a3b98f9f38f0b37829ae9a9184617d5419/pymongo-4.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4141e6c6a339789b2974efa00ecd9409101672d77a0e3ee2cc3839eedf8ec4df", size = 874668, upload-time = "2026-04-20T16:37:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8e/75d3c6c935d187ab59c61e9c15d9aab3f274b563eaf1706e8cae5f508dec/pymongo-4.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e68c76b84e0c132d9dbf9307f12ff8185702328187a87b9aca8c941303873433", size = 875294, upload-time = "2026-04-20T16:37:43.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ec/62e855744489dbcd54fd778aae4d80fa4c4819e8fb228ca0cf6f21a03997/pymongo-4.17.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba2195d4f386f839a52a23ea1cfd60ffaaba78a3d7841db51b7e433001139918", size = 1496233, upload-time = "2026-04-20T16:37:45.518Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e8/93e4e5e5ce8fdf8929dabeefe24aafa5ce046028eed0dfa8eeb936e72c49/pymongo-4.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446ff4bfcb6ec2a2e50998c860986a1e992136f998b7f53e7a717fb8aa5a0b9", size = 1522927, upload-time = "2026-04-20T16:37:47.492Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/425dc1d21e0f17bdea0072fc463f662f7fa06d2852af52975c9eced3c07c/pymongo-4.17.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2a0d5ac205728c86e0a02192f1aa5f865b0d7d51f8df6101c01a69a7fc620d72", size = 1583468, upload-time = "2026-04-20T16:37:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9d/f08b07eeffda1a43c1759f0fa625e88ae12360996eb56d42aad832fa7dff/pymongo-4.17.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:485c8a8eaa4c739f00a331fc73757898ee7c092c214a79e63866ff76aaf282ff", size = 1572787, upload-time = "2026-04-20T16:37:51.061Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c2/6855a07aafa7b894929af23675b6fb9634800ce43122b76a62f6eeb8da2a/pymongo-4.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2dfcc795f5b9fedbe179a11fdf6051581479d196582a3fe819a92a00e9b9969", size = 1526184, upload-time = "2026-04-20T16:37:53.358Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/05/c952bac7db71c1942ea3559fcd308b49754cc5004b455935fb4000d1f37b/pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510", size = 852621, upload-time = "2026-04-20T16:37:55.28Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c0/c04da9f4c0c6252404598f4e394b862a58a9e866822a70ae261c8a018fdf/pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9", size = 867852, upload-time = "2026-04-20T16:37:57.233Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b2/c7b4870fbeef471e947d3e014676f5910d02e0197074d692ebcf24ec049a/pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae", size = 855019, upload-time = "2026-04-20T16:37:58.983Z" },
+    { url = "https://files.pythonhosted.org/packages/98/90/60bcb508840135d5ee46b51b1a950f548338aa8145a8366dbe6639ae51ac/pymongo-4.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53ffa94b2340dbf6b055e09a0090618c60482c158ecfc9565642fc996bf0944", size = 930529, upload-time = "2026-04-20T16:38:00.936Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e9/313840f1e52c6dfac47f704428cbfbce59956ebe7633bffc92b03f74f0ad/pymongo-4.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fe0de9d0f6791abce3471230b32b4817bf89d27b1182b6a550e1ec0fa72aa9a", size = 930665, upload-time = "2026-04-20T16:38:02.915Z" },
+    { url = "https://files.pythonhosted.org/packages/78/35/9d3565ea45b1606f635c1e2cd2563c28d66caafdc50f7ad7d979fcd1b363/pymongo-4.17.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e537e95514dae1aaa718f481ec03151a0f0394bcd05f1322896d8fc1330cb729", size = 1762369, upload-time = "2026-04-20T16:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ee/149b0d4b1a11c38bff6f14c23d5814c9b0843fd6dc38ad40596bdb1a62d2/pymongo-4.17.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37a8385c29881b43eab31f584100fa0eaddedd5607adf010147ba1810118be90", size = 1798044, upload-time = "2026-04-20T16:38:07.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d4/4cee4a7b8d8f6f0550ef6cd2fea42455c5ed619a220cb6ba4fb40d6a5bc8/pymongo-4.17.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f3ee3d241ed77a4fc99ce3cff3b289c3ebce37f61fdd7349d3592c23b82c8784", size = 1878567, upload-time = "2026-04-20T16:38:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ef/7fe366c84952619ee2f69973566c214775e083dd4df465751912153e4b72/pymongo-4.17.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9eb5d63a3c518cb0804ed678f5e2b875af032d89a7cf57a57360322cf6a4d222", size = 1864881, upload-time = "2026-04-20T16:38:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/b577d82c6d1be7aee7ac7e249bc86f7847998345042e5f8360de238e177b/pymongo-4.17.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e97e03fa13327c87e3fdc5656acd01e71817f0c1dc3221cd8f30de136bf4ec3", size = 1800349, upload-time = "2026-04-20T16:38:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/69/dafcf04f66e130ddd91aeb92e7a692480eda46dcd04ec1dbe82c06619e10/pymongo-4.17.0-cp312-cp312-win32.whl", hash = "sha256:6877214bff5f06f6884a9fc8d9016a4a7a5f51f537f5c51ac3a576f93e7dfb32", size = 900518, upload-time = "2026-04-20T16:38:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/11/35/5c9262a459f988b4eb2605f70815240b77a0d4131136c4326d18f1822b89/pymongo-4.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:9828485f72f63c7d802e0ec41f71906f633c2692621ab3af55ca990186b091b1", size = 920335, upload-time = "2026-04-20T16:38:17.665Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/e9c7265ee176faccf4e52c4797837e794d93569a1046f6b19a4acc36e5ad/pymongo-4.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:1195370a77baf003b59b10e91ecc4706297197f0dd9d29c840cc556dc08f7cee", size = 903289, upload-time = "2026-04-20T16:38:19.33Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/c1206879708b94e82fcd8b9653440ec271f79a3674d122192df383047f5a/pymongo-4.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:809ec74de3b9148ae43fa8df9faf53470f511c8d384f13b99d6f671f2a379f15", size = 985829, upload-time = "2026-04-20T16:38:21.031Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/bb044ed85160e5c40f568c7c4f4e8ea16f40764ff5d302e5befbe8f6f814/pymongo-4.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a431b737816bf4cddd4fa0fcef04e424ad36b7692734a64150f872fb8f3208be", size = 985899, upload-time = "2026-04-20T16:38:23.409Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0a/f6dfd5ea3901e5d6888da8de8ba728971a1d447debab681cfc56f90d1208/pymongo-4.17.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4fab10f8403169ce92f3cea921609d9ee81107306caae06c08f592d4b8ad2b5", size = 2028569, upload-time = "2026-04-20T16:38:25.343Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c5/081f59a1c02ae8c0dc73ae58e563838c44eec81aeafa7d0b93a637841c9b/pymongo-4.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20323b0b1c1d33770ad1fc68d429c757734ce9ad3594421c3d6618f10572b1b9", size = 2072916, upload-time = "2026-04-20T16:38:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/31/42/6e41d434297ffe8b30d9c3717916591a4a7be9075a0dcc2fafdfaaaa62ed/pymongo-4.17.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5a5de048e6da5c18e27cc2437e8c15b3b0cdc8385c15b41178b0caa3322a09c2", size = 2173234, upload-time = "2026-04-20T16:38:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cf/1e4a7db352ef9485831c7268dfe8402f0117b32a9ad54b16e810699e3617/pymongo-4.17.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dff3de1294fbbc1db0ba6b511f77b8e540601d092538a31312e99c8a91a78b1e", size = 2156784, upload-time = "2026-04-20T16:38:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/12/10/6195be29962a61ebb5f4bd9e4c7519890b172f7968a0a0d880398c6ddb02/pymongo-4.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faf03e4c2aafd6de626dbd30ba246d369ae33f47f10629d1bbe40f72115027a6", size = 2074446, upload-time = "2026-04-20T16:38:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/33410b8819837ed370c738587306bdf060b59cef11823be212f4a07703c5/pymongo-4.17.0-cp313-cp313-win32.whl", hash = "sha256:c9786665926a09630c5d420c79762cfadbff35a9438bcbc4c81a9fb5ab9228b7", size = 948435, upload-time = "2026-04-20T16:38:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/77/c0ed522f798a286b99acaa7914ed8d9c80ab091f97f57c59ffed72906e5e/pymongo-4.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:5960519b4d7168f1ecdd3ea10c81b2aedeb9423651aca953cfbc8e76705d3b38", size = 972847, upload-time = "2026-04-20T16:38:37.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f0/c39480a2db385fde23861d0c8acda41cdaf1d43e46579db72c5c013a2e81/pymongo-4.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:0ff6bd2f735ab5356541e3e57d5b7dbfbc3f2ee1ccb10b6b0f82d58af69d1d8e", size = 951575, upload-time = "2026-04-20T16:38:40.544Z" },
+    { url = "https://files.pythonhosted.org/packages/da/49/2b0250762a89737ed6f9cea238331baca061b89a8ddd10dd17fee52c3970/pymongo-4.17.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff5aa3f1c7e3f08eb0e7a016c91ba468b1850ccfd63d9b1f12f56350f4974cef", size = 1040945, upload-time = "2026-04-20T16:38:42.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1c/7a9b5447a08be20e84b6e5b17330917e8d6d9507daa3cd099a9309f11ad7/pymongo-4.17.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e816db649ba5d7de0568cf3a9f287a9dc9aad21cf0ca667ab156a7ef47fca0b0", size = 1041187, upload-time = "2026-04-20T16:38:45.358Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a1/71704f61632dfc90407a5834fe5f6132854937c4a3648f6c05c351d85a45/pymongo-4.17.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c4fded3a9f1d6a687e36ebd384ac6d00b9b00de1969aa74048e7051ec2a713", size = 2294806, upload-time = "2026-04-20T16:38:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b9/aff42be75108b96c2469b1d9329b912c15108f3e7ef32fdc86da8423c330/pymongo-4.17.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2db66aa8dd253a0fc1fad3b0d23d5b3993f7ebde02fbbd7727128debf2853675", size = 2348231, upload-time = "2026-04-20T16:38:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/30/44c115b8ba1479942c15fd9480eb29a7da0ba68acd56983423ba0deb4a94/pymongo-4.17.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3987e96e7c7be4083d42e8ac2cc6c0d5b78db9973c90fce42ae800b616ca6b20", size = 2467614, upload-time = "2026-04-20T16:38:52.665Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/84/21ee95c8bf0ca7acae7ec7eb365d740bf8fc0156c194baf2c3bdfcb85ec0/pymongo-4.17.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cee36b3c0d0354f880fa7a7fdcdaf2bb5e542c2281e25c1bfadf8cfe21eba7d2", size = 2445970, upload-time = "2026-04-20T16:38:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/06/89/081d7f1809d5ca09d1e47e49f2111b245f5694de3a7af32cd3a353a6f43f/pymongo-4.17.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:320b34457b20bbcc79997801f95d25ce00472915ca5241167242b42c4359e027", size = 2348605, upload-time = "2026-04-20T16:38:57.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c3/0d949f9d3f2a341c1f635c398c16615e96f89f51ff424ed81e914cf1a4de/pymongo-4.17.0-cp314-cp314-win32.whl", hash = "sha256:df4a644af9ae132d4bfdb2e9516ea51a615fd881caddfbfbd071cf1354844479", size = 1004119, upload-time = "2026-04-20T16:39:00.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/55/5c3a3db1048054c695c75c5964cc8bedc2247fdb5a75ef6fab4ec8bb013e/pymongo-4.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:c797f8a80957134f6dd9690367a0f8f5906d672119af2c6aa55f0c527b656bed", size = 1032314, upload-time = "2026-04-20T16:39:02.665Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/19/e235f39906134cb0ffd5574c5a59c355ef5380f0499644ab94994afbb109/pymongo-4.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:68fca71e05ee5da23a8d73cee8379dfb3d26e609a377cae731d742771ed96946", size = 1007627, upload-time = "2026-04-20T16:39:04.678Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/c4c1a86791415b14c684fa0908f9da96de91594a3fd1fa1b8dc689fbb800/pymongo-4.17.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b4384700cffc3f1dd98e088bc0072dedf6d7d68a230bb4b972665cf69c071c1e", size = 1099151, upload-time = "2026-04-20T16:39:06.969Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4b/69c67f3e23fd9b23b9bedc7ebd23754881cc9d5c5d5b2a9811e96b07f475/pymongo-4.17.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:93641192644fa1ee0f34030e774fd31022a27ad11ba22cb1716142231524f8bd", size = 1099346, upload-time = "2026-04-20T16:39:08.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/19/a5208f62f9508a26d73acc69bd3821b8c8adae253679a3c26d2f9652f0d5/pymongo-4.17.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:75bc3aa5b94fdb7138d357ec6ca61cd97e0c79f4f7f0bd3efe9639b15cc50942", size = 2619034, upload-time = "2026-04-20T16:39:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/77/27/426cba1ec5973082a56d4150798529bfdf4151c31391ed1fbbecb23ef2ac/pymongo-4.17.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e8f8e23c6df7c6d6929f5e734980b227706e73ee847517c9ba5af90f7fc466", size = 2689939, upload-time = "2026-04-20T16:39:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2e/f70993d1255e33f6ee59a4ec4371cc65bff7a7e3fda7d55c3386f25287e8/pymongo-4.17.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:15d3f3d732aecac1f8d481bde4029755615639bd3076f258a2147210aec8515a", size = 2824994, upload-time = "2026-04-20T16:39:16.057Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/eb/87b0e988ba889e1fcc3430c2cfc166b251872c813e92b43174298bee17ff/pymongo-4.17.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5f62862d0f87be481fa1fe8cb811994486773c94a2b61e509285e3f2890763", size = 2801745, upload-time = "2026-04-20T16:39:18.476Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4c/3f83412d086f682d4d468761d66ddc49cf161e786ea74073045eb4491c60/pymongo-4.17.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64837adbbd72073301af51bb0fc80e3d7707fe5527cea1033ba0320f0b2f881b", size = 2684636, upload-time = "2026-04-20T16:39:20.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/b75f6f4ab6c8beb50b0270a4f1e2530b5774f5e116563440e1677ca1820f/pymongo-4.17.0-cp314-cp314t-win32.whl", hash = "sha256:b93b22eedc62598cf5ee9d8c8007a8e9121c50fd88137012d8985500e9dc3151", size = 1056356, upload-time = "2026-04-20T16:39:22.996Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5e/648c8a238eef18a25ed8a169ea6542d4a860bbec3e95b3d9badac2935c71/pymongo-4.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3689ea34f6b647c7d1e7bdc60fcfb214b2789ed1359a7fb96569c69f50e5f18f", size = 1090964, upload-time = "2026-04-20T16:39:24.989Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cb/d9780b66939c4fc1f024bcc7be23a2abcfe06a9745ca8fa76dc73395482e/pymongo-4.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9543d8f84c2e5608565c08ac679774811e6730770d8a645439b073422a4276fb", size = 1058526, upload-time = "2026-04-20T16:39:27.924Z" },
 ]
 
 [[package]]
@@ -5056,6 +5216,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+psycopg = [
+    { name = "psycopg", extra = ["binary"] },
+]
+pymongo = [
+    { name = "pymongo" },
+]
 tabular = [
     { name = "openpyxl" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -5094,7 +5260,9 @@ tests = [
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "poethepoet" },
     { name = "polyfactory" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pyarrow" },
+    { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -5121,9 +5289,11 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.39.1" },
     { name = "pandas", marker = "extra == 'tabular'", specifier = ">=2" },
     { name = "parsel", specifier = ">=1.11" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'psycopg'", specifier = ">=3.2" },
     { name = "pyarrow", marker = "extra == 'tabular'", specifier = ">=14" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "cerebras", "google", "groq", "huggingface", "mistral", "openai", "openrouter", "vertexai", "xai"], specifier = ">=1.74" },
+    { name = "pymongo", marker = "extra == 'pymongo'", specifier = ">=4.9" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "rich", specifier = ">=14.3" },
     { name = "rich-click", specifier = ">=1.9.7" },
@@ -5131,7 +5301,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "voidcrawl", specifier = ">=0.3.2" },
 ]
-provides-extras = ["tabular"]
+provides-extras = ["psycopg", "pymongo", "tabular"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5163,7 +5333,9 @@ tests = [
     { name = "pandas", specifier = ">=2" },
     { name = "poethepoet", specifier = ">=0.42" },
     { name = "polyfactory", specifier = ">=3.3" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pyarrow", specifier = ">=14" },
+    { name = "pymongo", specifier = ">=4.9" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "pytest-cov", specifier = ">=7.1" },

--- a/yosoi/__init__.py
+++ b/yosoi/__init__.py
@@ -42,6 +42,7 @@ from yosoi.models.contract import Contract
 from yosoi.models.defaults import JobPosting, NewsArticle, Product, Video
 from yosoi.models.selectors import FieldSelectors, SelectorEntry, SelectorLevel, css, discover, jsonld, regex, xpath
 from yosoi.models.snapshot import CacheVerdict, SelectorSnapshot, SnapshotMap, SnapshotStatus
+from yosoi.sinks import ContentRecord, ContentSink, MongoSink, PostgresSink, SqliteSink
 from yosoi.types import (
     Author,
     BodyText,
@@ -67,6 +68,8 @@ __all__ = [
     'BodyText',
     'CacheVerdict',
     'ClaudeSDKModel',
+    'ContentRecord',
+    'ContentSink',
     'Contract',
     'Datetime',
     'DebugConfig',
@@ -74,9 +77,11 @@ __all__ = [
     'FieldSelectors',
     'JobPosting',
     'LLMConfig',
+    'MongoSink',
     'NewsArticle',
     'OpenCodeModel',
     'Pipeline',
+    'PostgresSink',
     'Price',
     'Rating',
     'SelectorEntry',
@@ -84,6 +89,7 @@ __all__ = [
     'SelectorSnapshot',
     'SnapshotMap',
     'SnapshotStatus',
+    'SqliteSink',
     'TelemetryConfig',
     'Title',
     'Url',

--- a/yosoi/__init__.pyi
+++ b/yosoi/__init__.pyi
@@ -23,6 +23,11 @@ from yosoi.models.snapshot import CacheVerdict as CacheVerdict
 from yosoi.models.snapshot import SelectorSnapshot as SelectorSnapshot
 from yosoi.models.snapshot import SnapshotMap as SnapshotMap
 from yosoi.models.snapshot import SnapshotStatus as SnapshotStatus
+from yosoi.sinks import ContentRecord as ContentRecord
+from yosoi.sinks import ContentSink as ContentSink
+from yosoi.sinks import MongoSink as MongoSink
+from yosoi.sinks import PostgresSink as PostgresSink
+from yosoi.sinks import SqliteSink as SqliteSink
 from yosoi.types.base import YosoiType as YosoiType
 from yosoi.types.field import Field as Field
 from yosoi.types.registry import register_coercion as register_coercion

--- a/yosoi/sinks/AGENTS.md
+++ b/yosoi/sinks/AGENTS.md
@@ -18,3 +18,10 @@ from `yosoi/storage/`, which handles local-filesystem persistence of selectors/d
    output shape. Index on `url` and `scraped_at` in every backend.
 5. **Async + UTC**: All sink methods are async. Normalise timestamps with `_internal.to_utc`
    before storing or querying so ranges are consistent across backends.
+
+## Local dev / testing
+Postgres and Mongo round-trips live in `tests/integration/sinks/`. Bring up a local stack with
+`docker compose -f docker-compose.sinks.yml up -d` and point the tests at it via
+`YOSOI_TEST_POSTGRES_DSN` / `YOSOI_TEST_MONGO_URI` (see the compose file header). Without those env
+vars the tests fall back to ephemeral `testcontainers` instances, and skip entirely when neither a
+DSN nor Docker is available. SQLite needs nothing — it is covered by `tests/unit/sinks/`.

--- a/yosoi/sinks/AGENTS.md
+++ b/yosoi/sinks/AGENTS.md
@@ -1,0 +1,20 @@
+# Sinks Module Rules
+
+## Purpose
+Pluggable, append-only storage for extracted content. A `ContentSink` is the seam between
+Yosoi's extraction output and a downstream consumer's database of choice. This is distinct
+from `yosoi/storage/`, which handles local-filesystem persistence of selectors/debug data.
+
+## Constraints
+1. **Narrow interface**: The `ContentSink` Protocol stays append-only and content-only —
+   `write`, `read_by_url`, `read_by_time`, `close`. No entity resolution, canonicalisation, or
+   consumer-specific concepts; those live in the downstream repo.
+2. **Append-only**: `write` always inserts a new record; never update or overwrite. `scraped_at`
+   distinguishes versions.
+3. **Lazy drivers**: Database drivers are optional extras. Import them lazily inside the backend
+   (never at module top level) and raise a helpful "install yosoi[<extra>]" message via
+   `_internal.missing_dependency`. Core must import only the interface + record contract.
+4. **Record contract**: `ContentRecord` (`url`, `content`, `scraped_at`, `source`) is the public
+   output shape. Index on `url` and `scraped_at` in every backend.
+5. **Async + UTC**: All sink methods are async. Normalise timestamps with `_internal.to_utc`
+   before storing or querying so ranges are consistent across backends.

--- a/yosoi/sinks/__init__.py
+++ b/yosoi/sinks/__init__.py
@@ -1,0 +1,29 @@
+"""Pluggable, append-only content sinks for extracted content.
+
+Exposes a narrow :class:`ContentSink` interface and three backends — SQLite
+(stdlib), PostgreSQL, and MongoDB. Importing this package pulls in only the
+interface and the record contract; database drivers are imported lazily inside
+each backend and fail with a helpful message if the matching extra is missing.
+
+Example::
+
+    from yosoi.sinks import ContentRecord, SqliteSink
+
+    async with SqliteSink('.yosoi/content.db') as sink:
+        await sink.write(ContentRecord(url='https://x.com', content={'title': 'Hi'}, source='demo'))
+        history = await sink.read_by_url('https://x.com')
+"""
+
+from yosoi.sinks.base import ContentSink
+from yosoi.sinks.mongo import MongoSink
+from yosoi.sinks.postgres import PostgresSink
+from yosoi.sinks.record import ContentRecord
+from yosoi.sinks.sqlite import SqliteSink
+
+__all__ = [
+    'ContentRecord',
+    'ContentSink',
+    'MongoSink',
+    'PostgresSink',
+    'SqliteSink',
+]

--- a/yosoi/sinks/_internal.py
+++ b/yosoi/sinks/_internal.py
@@ -1,0 +1,38 @@
+"""Shared internals for sink backends: driver-import errors and time helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+class MissingSinkDependencyError(ImportError):
+    """Raised when an optional sink driver is not installed.
+
+    Subclasses :class:`ImportError` so existing ``except ImportError`` handlers
+    keep working, while the message tells the user exactly which extra to add.
+    """
+
+
+def missing_dependency(driver: str, extra: str) -> MissingSinkDependencyError:
+    """Build a helpful error for a missing optional driver.
+
+    Args:
+        driver: The import name that failed (e.g. ``'pymongo'``).
+        extra: The Yosoi extra that provides it (e.g. ``'mongo'``).
+
+    """
+    return MissingSinkDependencyError(
+        f'{driver} is required for this sink but is not installed. '
+        f"Install it with: uv add 'yosoi[{extra}]'  (or: pip install 'yosoi[{extra}]')"
+    )
+
+
+def to_utc(dt: datetime) -> datetime:
+    """Normalise a datetime to timezone-aware UTC.
+
+    Naive datetimes are assumed to already be UTC. This keeps stored timestamps
+    comparable across backends and makes ISO-string range queries correct.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)

--- a/yosoi/sinks/base.py
+++ b/yosoi/sinks/base.py
@@ -1,0 +1,51 @@
+"""The narrow, append-only :class:`ContentSink` interface.
+
+A sink is the seam between Yosoi's extraction output and wherever a downstream
+consumer wants to read it from. The interface is intentionally tiny — append a
+record, read records back by url, read records back by time — and carries no
+entity- or consumer-specific concepts. Backends (SQLite, Postgres, Mongo) are a
+choice, not a commitment.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+from yosoi.sinks.record import ContentRecord
+
+
+@runtime_checkable
+class ContentSink(Protocol):
+    """Append-only store for extracted :class:`ContentRecord` documents.
+
+    Implementations are async and own their own connection lifecycle. They may
+    be used as async context managers; :meth:`close` releases the underlying
+    driver resources.
+
+    Semantics are append-only: :meth:`write` always inserts a new row/document
+    and never updates an existing one. Reads return every matching version,
+    newest-first, so callers can pick the latest or inspect history.
+    """
+
+    async def write(self, doc: ContentRecord) -> None:
+        """Append ``doc`` to the store. Never overwrites a prior record."""
+        ...
+
+    async def read_by_url(self, url: str) -> list[ContentRecord]:
+        """Return every record for ``url``, ordered newest-first by ``scraped_at``."""
+        ...
+
+    async def read_by_time(self, start: datetime, end: datetime | None = None) -> list[ContentRecord]:
+        """Return records with ``start <= scraped_at <= end``, newest-first.
+
+        Args:
+            start: Inclusive lower bound on ``scraped_at``.
+            end: Inclusive upper bound. ``None`` means open-ended (up to now).
+
+        """
+        ...
+
+    async def close(self) -> None:
+        """Release any driver/connection resources held by the sink."""
+        ...

--- a/yosoi/sinks/mongo.py
+++ b/yosoi/sinks/mongo.py
@@ -1,0 +1,94 @@
+"""MongoDB content sink (requires the ``mongo`` extra).
+
+Backed by PyMongo's async ``AsyncMongoClient``. The driver is imported lazily so
+that a bare ``yosoi`` install does not depend on it; a missing driver fails with
+a helpful ``uv add 'yosoi[pymongo]'`` message rather than a raw ImportError.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from yosoi.sinks._internal import missing_dependency, to_utc
+from yosoi.sinks.record import ContentRecord
+
+
+def _import_async_client() -> Any:
+    try:
+        from pymongo import AsyncMongoClient
+
+        return AsyncMongoClient
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch in tests
+        raise missing_dependency('pymongo', 'pymongo') from exc
+
+
+class MongoSink:
+    """Append-only :class:`~yosoi.sinks.base.ContentSink` backed by MongoDB.
+
+    Each record is stored as a document ``{url, content, scraped_at, source}``.
+    Indexes on ``url`` and ``scraped_at`` are ensured on first write.
+
+    Args:
+        uri: MongoDB connection string (e.g. ``'mongodb://localhost:27017'``).
+        database: Database name. Defaults to ``'yosoi'``.
+        collection: Collection name. Defaults to ``'content'``.
+
+    """
+
+    def __init__(self, uri: str, *, database: str = 'yosoi', collection: str = 'content') -> None:
+        """Create the sink. Imports the pymongo driver eagerly (see class docstring)."""
+        client_cls = _import_async_client()
+        self._client: Any = client_cls(uri)
+        self._collection: Any = self._client[database][collection]
+        self._indexes_ready = False
+
+    async def _ensure_indexes(self) -> None:
+        if self._indexes_ready:
+            return
+        await self._collection.create_index('url')
+        await self._collection.create_index('scraped_at')
+        self._indexes_ready = True
+
+    @staticmethod
+    def _to_record(doc: dict[str, Any]) -> ContentRecord:
+        return ContentRecord(url=doc['url'], content=doc['content'], scraped_at=doc['scraped_at'], source=doc['source'])
+
+    async def write(self, doc: ContentRecord) -> None:
+        """Append ``doc`` as a new document. Never overwrites."""
+        await self._ensure_indexes()
+        await self._collection.insert_one(
+            {
+                'url': doc.url,
+                'content': doc.content,
+                'scraped_at': to_utc(doc.scraped_at),
+                'source': doc.source,
+            }
+        )
+
+    async def _find(self, query: dict[str, Any]) -> list[ContentRecord]:
+        cursor = self._collection.find(query, projection={'_id': False}).sort('scraped_at', -1)
+        return [self._to_record(doc) async for doc in cursor]
+
+    async def read_by_url(self, url: str) -> list[ContentRecord]:
+        """Return every record for ``url``, newest-first."""
+        return await self._find({'url': url})
+
+    async def read_by_time(self, start: datetime, end: datetime | None = None) -> list[ContentRecord]:
+        """Return records with ``start <= scraped_at <= end``, newest-first."""
+        bounds: dict[str, Any] = {'$gte': to_utc(start)}
+        if end is not None:
+            bounds['$lte'] = to_utc(end)
+        return await self._find({'scraped_at': bounds})
+
+    async def close(self) -> None:
+        """Close the underlying client."""
+        await self._client.close()
+
+    async def __aenter__(self) -> MongoSink:
+        """Enter the async context, returning the sink."""
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        """Exit the async context, closing the client."""
+        await self.close()

--- a/yosoi/sinks/postgres.py
+++ b/yosoi/sinks/postgres.py
@@ -1,0 +1,139 @@
+"""PostgreSQL content sink (requires the ``psycopg`` extra).
+
+Backed by psycopg 3's async API. The driver is imported lazily so that a bare
+``yosoi`` install does not depend on it; a missing driver fails with a helpful
+``uv add 'yosoi[psycopg]'`` message rather than a raw ImportError.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from yosoi.sinks._internal import missing_dependency, to_utc
+from yosoi.sinks.record import ContentRecord
+
+
+def _import_psycopg() -> Any:
+    try:
+        import psycopg
+        import psycopg.rows
+        import psycopg.sql
+        import psycopg.types.json
+
+        return psycopg
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch in tests
+        raise missing_dependency('psycopg', 'psycopg') from exc
+
+
+class PostgresSink:
+    """Append-only :class:`~yosoi.sinks.base.ContentSink` backed by PostgreSQL.
+
+    Content is stored in a ``JSONB`` column; ``scraped_at`` in ``TIMESTAMPTZ``.
+    The table and its indexes are created on first use if absent.
+
+    Args:
+        conninfo: A libpq connection string or URL
+            (e.g. ``'postgresql://user:pw@host:5432/db'``).
+        table: Destination table name. Defaults to ``'content'``.
+
+    """
+
+    def __init__(self, conninfo: str, *, table: str = 'content') -> None:
+        """Create the sink. Imports the psycopg driver eagerly (see class docstring)."""
+        self._psycopg = _import_psycopg()
+        self._conninfo = conninfo
+        self._table = table
+        self._conn: Any = None
+        self._ready = False
+
+    @property
+    def _table_ident(self) -> Any:
+        return self._psycopg.sql.Identifier(self._table)
+
+    async def _connection(self) -> Any:
+        if self._conn is None or self._conn.closed:
+            self._conn = await self._psycopg.AsyncConnection.connect(self._conninfo, autocommit=True)
+            self._ready = False
+        if not self._ready:
+            await self._ensure_schema(self._conn)
+            self._ready = True
+        return self._conn
+
+    async def _ensure_schema(self, conn: Any) -> None:
+        sql = self._psycopg.sql
+        await conn.execute(
+            sql.SQL(
+                'CREATE TABLE IF NOT EXISTS {table} ('
+                'id BIGSERIAL PRIMARY KEY, '
+                'url TEXT NOT NULL, '
+                'content JSONB NOT NULL, '
+                'scraped_at TIMESTAMPTZ NOT NULL, '
+                'source TEXT NOT NULL)'
+            ).format(table=self._table_ident)
+        )
+        await conn.execute(
+            sql.SQL('CREATE INDEX IF NOT EXISTS {idx} ON {table} (url)').format(
+                idx=sql.Identifier(f'idx_{self._table}_url'), table=self._table_ident
+            )
+        )
+        await conn.execute(
+            sql.SQL('CREATE INDEX IF NOT EXISTS {idx} ON {table} (scraped_at)').format(
+                idx=sql.Identifier(f'idx_{self._table}_scraped_at'), table=self._table_ident
+            )
+        )
+
+    def _to_record(self, row: dict[str, Any]) -> ContentRecord:
+        return ContentRecord(url=row['url'], content=row['content'], scraped_at=row['scraped_at'], source=row['source'])
+
+    async def write(self, doc: ContentRecord) -> None:
+        """Append ``doc`` as a new row. Never overwrites."""
+        conn = await self._connection()
+        jsonb = self._psycopg.types.json.Jsonb
+        sql = self._psycopg.sql
+        await conn.execute(
+            sql.SQL('INSERT INTO {table} (url, content, scraped_at, source) VALUES (%s, %s, %s, %s)').format(
+                table=self._table_ident
+            ),
+            (doc.url, jsonb(doc.content), to_utc(doc.scraped_at), doc.source),
+        )
+
+    async def _fetch(self, where_sql: Any, params: tuple[Any, ...]) -> list[ContentRecord]:
+        conn = await self._connection()
+        sql = self._psycopg.sql
+        dict_row = self._psycopg.rows.dict_row
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                sql.SQL('SELECT url, content, scraped_at, source FROM {table} WHERE ').format(table=self._table_ident)
+                + where_sql
+                + sql.SQL(' ORDER BY scraped_at DESC'),
+                params,
+            )
+            rows = await cur.fetchall()
+        return [self._to_record(row) for row in rows]
+
+    async def read_by_url(self, url: str) -> list[ContentRecord]:
+        """Return every record for ``url``, newest-first."""
+        return await self._fetch(self._psycopg.sql.SQL('url = %s'), (url,))
+
+    async def read_by_time(self, start: datetime, end: datetime | None = None) -> list[ContentRecord]:
+        """Return records with ``start <= scraped_at <= end``, newest-first."""
+        sql = self._psycopg.sql
+        if end is None:
+            return await self._fetch(sql.SQL('scraped_at >= %s'), (to_utc(start),))
+        return await self._fetch(sql.SQL('scraped_at >= %s AND scraped_at <= %s'), (to_utc(start), to_utc(end)))
+
+    async def close(self) -> None:
+        """Close the underlying connection if open."""
+        if self._conn is not None and not self._conn.closed:
+            await self._conn.close()
+        self._conn = None
+        self._ready = False
+
+    async def __aenter__(self) -> PostgresSink:
+        """Enter the async context, returning the sink."""
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        """Exit the async context, closing the connection."""
+        await self.close()

--- a/yosoi/sinks/record.py
+++ b/yosoi/sinks/record.py
@@ -1,0 +1,40 @@
+"""The content record contract shared by every :class:`ContentSink` backend.
+
+This is Yosoi's public output shape for extracted content. It is deliberately
+narrow and makes no assumptions about the database underneath: a record is just
+*what* was scraped (``content``), *where* from (``url`` / ``source``), and
+*when* (``scraped_at``). Entity resolution and canonicalisation belong in the
+downstream consumer, not here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field, JsonValue
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ContentRecord(BaseModel):
+    """A single append-only unit of extracted content.
+
+    Every scrape produces a new record; sinks never overwrite. ``scraped_at``
+    is what distinguishes successive versions of the same ``url``.
+
+    Attributes:
+        url: The page the content was extracted from.
+        content: The extracted payload. Any JSON-serialisable value — typically
+            a dict for single-item pages or a list of dicts for multi-item pages.
+        scraped_at: Timezone-aware capture time. Defaults to ``now()`` in UTC.
+        source: Free-form provenance label (e.g. the fetcher tier, pipeline
+            name, or run id) chosen by the producer.
+
+    """
+
+    url: str
+    content: JsonValue
+    scraped_at: datetime = Field(default_factory=_utc_now)
+    source: str

--- a/yosoi/sinks/sqlite.py
+++ b/yosoi/sinks/sqlite.py
@@ -1,0 +1,125 @@
+"""SQLite content sink.
+
+Uses the stdlib :mod:`sqlite3` driver — no optional extra required. Each
+operation is run in a worker thread via :func:`asyncio.to_thread` so the
+synchronous driver does not block the event loop. Connections are opened
+per-operation (cheap for SQLite) which keeps the sink safe to share across
+tasks without juggling sqlite3's thread affinity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from yosoi.sinks._internal import to_utc
+from yosoi.sinks.record import ContentRecord
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS content (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url TEXT NOT NULL,
+    content TEXT NOT NULL,
+    scraped_at TEXT NOT NULL,
+    source TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_content_url ON content (url);
+CREATE INDEX IF NOT EXISTS idx_content_scraped_at ON content (scraped_at);
+"""
+
+
+class SqliteSink:
+    """Append-only :class:`~yosoi.sinks.base.ContentSink` backed by a SQLite file.
+
+    Args:
+        db_path: Path to the SQLite database file. Parent directories are
+            created on first write. Use ``':memory:'`` for an ephemeral store
+            (note: a fresh in-memory DB is created per connection, so this is
+            only useful within a single short-lived sink instance kept open).
+
+    """
+
+    def __init__(self, db_path: str | os.PathLike[str]) -> None:
+        """Create the sink (see class docstring for ``db_path`` semantics)."""
+        self._db_path = str(db_path)
+
+    def _open(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _write_sync(self, url: str, content: str, scraped_at: str, source: str) -> None:
+        if self._db_path != ':memory:':
+            Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        conn = self._open()
+        try:
+            conn.executescript(_SCHEMA)
+            conn.execute(
+                'INSERT INTO content (url, content, scraped_at, source) VALUES (?, ?, ?, ?)',
+                (url, content, scraped_at, source),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _query_sync(self, where: str, params: tuple[str, ...]) -> list[sqlite3.Row]:
+        conn = self._open()
+        try:
+            conn.executescript(_SCHEMA)
+            cursor = conn.execute(
+                f'SELECT url, content, scraped_at, source FROM content WHERE {where} ORDER BY scraped_at DESC',
+                params,
+            )
+            return cursor.fetchall()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _to_record(row: sqlite3.Row) -> ContentRecord:
+        return ContentRecord(
+            url=row['url'],
+            content=json.loads(row['content']),
+            scraped_at=datetime.fromisoformat(row['scraped_at']),
+            source=row['source'],
+        )
+
+    async def write(self, doc: ContentRecord) -> None:
+        """Append ``doc`` as a new row. Never overwrites."""
+        await asyncio.to_thread(
+            self._write_sync,
+            doc.url,
+            json.dumps(doc.content),
+            to_utc(doc.scraped_at).isoformat(),
+            doc.source,
+        )
+
+    async def read_by_url(self, url: str) -> list[ContentRecord]:
+        """Return every record for ``url``, newest-first."""
+        rows = await asyncio.to_thread(self._query_sync, 'url = ?', (url,))
+        return [self._to_record(row) for row in rows]
+
+    async def read_by_time(self, start: datetime, end: datetime | None = None) -> list[ContentRecord]:
+        """Return records with ``start <= scraped_at <= end``, newest-first."""
+        start_iso = to_utc(start).isoformat()
+        if end is None:
+            rows = await asyncio.to_thread(self._query_sync, 'scraped_at >= ?', (start_iso,))
+        else:
+            rows = await asyncio.to_thread(
+                self._query_sync, 'scraped_at >= ? AND scraped_at <= ?', (start_iso, to_utc(end).isoformat())
+            )
+        return [self._to_record(row) for row in rows]
+
+    async def close(self) -> None:
+        """No-op: connections are opened per-operation and closed immediately."""
+
+    async def __aenter__(self) -> SqliteSink:
+        """Enter the async context, returning the sink."""
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        """Exit the async context (no-op close)."""
+        await self.close()


### PR DESCRIPTION
## Summary

Implements [CAS-74](https://linear.app/cascadinglabs/issue/CAS-74/pluggable-content-sink-for-extracted-content-postgres-mongo-sqlite): a narrow, **append-only**, **content-only** sink interface for extracted content, with three pluggable backends. The backend is a choice, not a commitment — a downstream consumer constructs a sink and reads scraped content immediately.

Per scope discussion: the interface is **async**, ships as a **standalone module** (no auto-wiring into the scrape pipeline), and makes **no assumptions about the database**.

## What's here

- **`ContentRecord`** — the public output shape: `url`, `content` (any JSON value), `scraped_at` (UTC), `source`. Every scrape is a new record; `scraped_at` distinguishes versions.
- **`ContentSink` Protocol** (async, `runtime_checkable`): `write` / `read_by_url` / `read_by_time` + `close`. Reads return all versions newest-first.
- **Three backends**, each indexing `url` and `scraped_at`:
  - `SqliteSink` — stdlib `sqlite3` via `asyncio.to_thread` (**no extra needed**).
  - `PostgresSink` — psycopg 3 async, `JSONB` content.
  - `MongoSink` — pymongo `AsyncMongoClient`.
- **Optional extras** named after the driver packages — `yosoi[psycopg]`, `yosoi[pymongo]`. Drivers are imported **lazily** at construction; a missing one raises `MissingSinkDependencyError` (an `ImportError` subclass) with an `install yosoi[...]` message, not a raw traceback.
- Exported from the public API + `__init__.pyi`.
- **`docker-compose.sinks.yml`** — local Postgres/Mongo dev stack (overridable host ports) so devs can run the integration tests against a persistent stack instead of per-run testcontainers.

## Acceptance criteria

- [x] Same interface across all three backends.
- [x] Round-trip write → read-by-url & read-by-time, **per backend** (SQLite via unit tests; Postgres 16 + Mongo 7 via testcontainers / the compose stack).
- [x] Bare `pip install yosoi` does not pull Mongo/Postgres drivers (extras + test-group only; verified `import yosoi` imports neither driver).

## Tests run

- `uv run poe ci-check` — green (lint/format/mypy + **1953 passed**, coverage **93.36%**).
- Sink integration round-trips verified both against the live compose stack (~0.2s) and via testcontainers fallback (~9s); idempotent across re-runs with per-test unique table/database + cleanup.

## Notes / follow-ups

- `postgres.py` / `mongo.py` are coverage-omitted (driver-dependent), matching the existing `voiddriver.py` precedent — their logic is guarded by container integration tests, which need Docker in CI.
- The interface is async; a sync consumer must call from a thread/event loop. `PostgresSink` holds a single connection per instance — fine for the immediate use, worth revisiting under high concurrency.
- Compose default ports are 5433/27018, overridable via `YOSOI_PG_PORT`/`YOSOI_MONGO_PORT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)