### PR TITLE
ci: add CVE gate (Python + JS/bun)

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,27 @@
+# Dependency CVE gate — be proactive instead of waiting on Dependabot.
+# Scanners live in CascadingLabs/.github (reusable workflows); update them once,
+# every repo inherits the change. See that repo's .github/workflows/cve-*.yml.
+
+name: Security (CVE)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    uses: CascadingLabs/.github/.github/workflows/cve-python.yml@main
+  js:
+    uses: CascadingLabs/.github/.github/workflows/cve-js.yml@main
+    with:
+      package-manager: bun


### PR DESCRIPTION
Calls the reusable CVE-gate workflows in CascadingLabs/.github (Python via uv.lock, JS via bun.lock).

Depends on CascadingLabs/.github#— merge that PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)