### PR TITLE
fix(licenses): plug GPL leak in pip-licenses allow-only + add bundled…

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Check dependency licenses
         run: uv run poe licenses
 
+      - name: Scan native deps for vendored copyleft
+        run: uv run poe licenses-binary
+
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,13 +237,24 @@ ignore-packages = [
   "mistralai",           # Apache-2.0 (missing metadata, verified via GitHub)
   "taskiq-dependencies", # MIT (missing metadata, verified via GitHub)
 ]
+# Permissive allow-list. MPL-2.0 is intentionally allowed: it is weak/file-level
+# copyleft and only reaches us via unremovable transitive deps (certifi <- httpx,
+# tqdm <- openai, pathspec <- mypy), none of which we fork.
+# WARNING: `allow-only` is split on ';'. Never paste a package's *compound* classifier
+# string (e.g. "BSD License; GNU General Public License (GPL); Public Domain") in whole
+# — it fragments into separate tokens and silently allows GPL. Add a single canonical
+# token, or use `ignore-packages` for a specific dep. `fail-on` below is the backstop.
 allow-only = """\
   Apache Software License;Apache-2.0;Apache-2.0 AND MIT;Apache-2.0 AND CNRI-Python;Apache-2.0 OR BSD-3-Clause;Apache \
   License 2.0;MIT;MIT License;MIT AND PSF-2.0;BSD License;BSD-2-Clause;BSD-3-Clause;BSD-3-Clause AND 0BSD AND MIT AND \
   Zlib AND CC0-1.0;3-Clause BSD License;ISC;ISC License (ISCL);PSF-2.0;Python Software Foundation \
-  License;MPL-2.0;MPL-2.0 AND MIT;Mozilla Public License 2.0 (MPL 2.0);The Unlicense (Unlicense);BSD License; GNU \
-  General Public License (GPL); Public Domain;Apache Software License; BSD License;Apache Software License; MIT License\
+  License;MPL-2.0;MPL-2.0 AND MIT;Mozilla Public License 2.0 (MPL 2.0);The Unlicense (Unlicense);Apache Software \
+  License; BSD License;Apache Software License; MIT License\
   """
+# Hard denylist — copyleft families we will not ship, regardless of `allow-only`.
+# (MPL deliberately excluded; see note above.) With partial-match, "GPL" also catches
+# LGPL/AGPL. This is what keeps a re-pasted compound string from leaking GPL again.
+fail-on = "GPL;LGPL;AGPL"
 partial-match = true
 
 [tool.mutmut]
@@ -301,7 +312,8 @@ tasks.ci-format = "uv run ruff check --fix"
 tasks.coverage = "uv run pytest --cov=yosoi --cov-report=term-missing --cov-report=html tests/"
 tasks.mutmut-run = "uv run mutmut run"
 tasks.mutmut-results = "uv run mutmut results"
-tasks.licenses = "uv run pip-licenses"  # check dependency licenses
+tasks.licenses = "uv run pip-licenses"  # check declared dependency licenses (metadata gate)
+tasks.licenses-binary = "uv run python scripts/scan_binary_licenses.py --skip claude_agent_sdk/_bundled"  # scan bundled native deps for vendored copyleft; skip claude_agent_sdk/_bundled (bundled AGPL CLI tool, not shipped in yosoi's wheel)
 tasks.docs = "uv run python scripts/generate_api_docs.py --output-dir ../CascadingLabsFE/docs/yosoi-docs/reference"  # generate split API reference with GitHub source links
 tasks.bump = "uv run cz bump --yes"  # auto-detect from conventional commits
 tasks.bump-dry = "uv run cz bump --dry-run"  # preview what the next bump would be

--- a/scripts/scan_binary_licenses.py
+++ b/scripts/scan_binary_licenses.py
@@ -1,0 +1,156 @@
+"""Scan installed native extensions for *vendored* copyleft code.
+
+`pip-licenses` (and `cargo-deny`) only see a package's **declared** license
+metadata. They are blind to third-party C libraries statically linked into a
+wheel's compiled ``.so`` — e.g. a wheel published as "MIT" can vendor LGPL
+``libidn2`` into its extension module, and the metadata gate happily passes it.
+This scanner closes that blind spot by grepping the actual shipped binaries for
+copyleft fingerprints (GNU licence URLs, ``libidn2`` build paths, GPL/LGPL/AGPL
+strings).
+
+It is a coarse net, not a legal audit. C/Go bundles embed identifying strings
+(source paths, ``gnu.org`` URLs), so a *hit* is reliable. Stripped Rust binaries
+do **not** embed licence text — their crate metadata carries the licence — so the
+*absence* of a hit is not proof of cleanliness. Pair this with the declared-metadata
+gate (``poe licenses``); together they cover both layers.
+
+MPL-2.0 is intentionally **not** flagged here: it is allowed by policy (weak,
+file-level, only reaches us via unremovable transitive deps). This net targets the
+copyleft families we will not ship — the GPL/LGPL/AGPL lineage, ``libidn2`` included.
+
+Exit code 1 on any hit, 0 if clean. Wired into CI via ``poe licenses-binary``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import sysconfig
+from collections.abc import Iterable
+from pathlib import Path
+
+# Each pattern is a string a copyleft component leaves in a compiled artifact.
+_COPYLEFT_MARKERS: tuple[bytes, ...] = (
+    rb'gnu\.org/licenses/l?gpl',
+    rb'GNU (?:Lesser )?General Public License',
+    rb'\blibidn2?\b',
+    rb'idn2[-_][0-9]',
+    rb'GPLv[23]',
+    rb'LGPLv[23]',
+    rb'\bAGPL',
+)
+_PATTERN = re.compile(b'|'.join(_COPYLEFT_MARKERS))
+_BINARY_SUFFIXES = frozenset({'.so', '.dylib', '.pyd'})
+
+# ELF and Mach-O magic bytes — covers Linux/Windows native executables and macOS binaries.
+_ELF_MAGIC = b'\x7fELF'
+_MACHO_MAGIC = frozenset(
+    {
+        b'\xfe\xed\xfa\xce',  # Mach-O 32-bit BE
+        b'\xfe\xed\xfa\xcf',  # Mach-O 64-bit BE
+        b'\xce\xfa\xed\xfe',  # Mach-O 32-bit LE
+        b'\xcf\xfa\xed\xfe',  # Mach-O 64-bit LE
+        b'\xca\xfe\xba\xbe',  # Mach-O fat binary
+    }
+)
+
+
+def _is_native_executable(path: Path) -> bool:
+    """Return True if path starts with ELF or Mach-O magic bytes."""
+    try:
+        header = path.read_bytes()[:4]
+    except OSError:
+        return False
+    return header == _ELF_MAGIC or header in _MACHO_MAGIC
+
+
+def _iter_binaries(roots: Iterable[Path]) -> Iterable[Path]:
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in root.rglob('*'):
+            if not path.is_file():
+                continue
+            if path.suffix in _BINARY_SUFFIXES or '.so.' in path.name:
+                yield path
+            elif not path.suffix and _is_native_executable(path):
+                # Extensionless native executables from binary wheels (e.g. ruff, prek).
+                yield path
+
+
+def scan(roots: Iterable[Path], skip: Iterable[str] = ()) -> dict[Path, set[str]]:
+    """Return a mapping of binary path -> set of copyleft markers found in it.
+
+    ``skip`` is a sequence of path substrings; any binary whose str() contains one
+    of them is excluded from the results.  Use it for known-acceptable copyleft
+    binaries that are intentionally bundled by a dependency (e.g. a tool that ships
+    its own AGPL CLI for convenience but does not infect yosoi's wheel).
+    """
+    skip_patterns = list(skip)
+    hits: dict[Path, set[str]] = {}
+    for path in _iter_binaries(roots):
+        if any(s in str(path) for s in skip_patterns):
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        found = {m.group(0).decode('latin-1') for m in _PATTERN.finditer(data)}
+        if found:
+            hits[path] = found
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Scan ``roots`` (default: site-packages) and exit non-zero on any copyleft hit."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'roots',
+        nargs='*',
+        type=Path,
+        help="Directories to scan (default: this interpreter's site-packages).",
+    )
+    parser.add_argument(
+        '--skip',
+        metavar='PATTERN',
+        action='append',
+        default=[],
+        help=(
+            'Path substring to exclude from scanning.  Repeat for multiple patterns. '
+            'Use for known-acceptable copyleft binaries that a dependency bundles as a '
+            "convenience tool and that do not reach yosoi's own wheel."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.roots:
+        roots: list[Path] = args.roots
+    else:
+        # purelib = pure-Python packages; platlib = native extensions (.so/.pyd);
+        # scripts = installed executables (extensionless CLI binaries like ruff).
+        sp = sysconfig.get_paths()
+        roots = list({Path(sp[k]) for k in ('purelib', 'platlib', 'scripts')})
+
+    print(f'scanning native extensions under: {", ".join(map(str, roots))}')
+    if args.skip:
+        print(f'skipping path patterns: {", ".join(args.skip)}')
+    hits = scan(roots, skip=args.skip)
+    if not hits:
+        print('OK: no copyleft fingerprints in any bundled binary')
+        return 0
+
+    print('FAIL: copyleft fingerprints found in bundled binaries:', file=sys.stderr)
+    for path, markers in sorted(hits.items()):
+        print(f'  {path}', file=sys.stderr)
+        for marker in sorted(markers):
+            print(f'      {marker}', file=sys.stderr)
+    print(
+        f"\n{len(hits)} binary(ies) carry copyleft fingerprints. Inspect the wheel's "
+        'vendored sources before shipping (see scan_binary_licenses docstring).',
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
…-binary copyleft scan (#89)

* fix(licenses): plug GPL leak in allow-only and add bundled-binary scan

The pip-licenses `allow-only` list contained the compound classifier string "BSD License; GNU General Public License (GPL); Public Domain", which pip-licenses splits on ';' — silently allowing GPL (amplified by partial-match). No installed package relied on those tokens.

- Remove the GPL/Public-Domain fragment from allow-only. MPL-2.0 stays allowed by policy (weak/file-level, only via unremovable transitive deps certifi<-httpx, tqdm<-openai, pathspec<-mypy).
- Add `fail-on = "GPL;LGPL;AGPL"` as a hard backstop so a re-pasted compound string can't leak copyleft again.
- Add scripts/scan_binary_licenses.py + `poe licenses-binary`, wired into the CI License Check job — catches copyleft vendored into a wheel's compiled .so (e.g. LGPL libidn2), which the pip-licenses metadata gate cannot see.



* fix(licenses): scan extensionless native executables + fix default scan roots

Address P2 review comment: _iter_binaries only matched files with .so/.dylib/.pyd suffixes, silently missing extensionless CLI binaries from binary wheels (e.g. ruff, prek). Added _is_native_executable() which checks ELF/Mach-O magic bytes, and yields extensionless files that match.

Also fix two related blind spots surfaced during local testing:
- Default scan path was purelib (pure-Python only); native .so files officially live in platlib, and CLI executables land in scripts. Now scans all three.
- claude_agent_sdk bundles an AGPL Claude CLI binary. Added --skip PATTERN flag to scan() / main() and wire it into the poe task for known-acceptable bundled tools that do not appear in yosoi's own wheel.



---------

<!-- Link the issue this PR addresses. If there is no issue, consider creating one first. -->

- Closes #<issue>

## Intent

<!-- What does this PR do and why? -->

## Changes

<!-- Summarize what was changed. -->

## GenAI Usage

- [ ] AI-generated code was used in this PR

<!-- If checked, briefly describe how AI was used (e.g., tool, prompts, which parts). -->
<!-- All AI-generated code must be reviewed line-by-line by the PR author. -->

## Risks

<!-- Any risks or side effects this change might introduce? If none, write "None." -->

## Checklist

- [ ] Branch is based on `main`
- [ ] CI passes (lint, type check, tests)
- [ ] Changes are focused -one logical change per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
