### PR TITLE
feat(CAS-94): de-hardcode coercion, descriptions, selectors + selecto…

### DIFF
--- a/examples/claude_sdk_example.py
+++ b/examples/claude_sdk_example.py
@@ -23,7 +23,7 @@ class Book(ys.Contract):
     price: float = ys.Price(description='Book price — always includes £ symbol')
     # Rating is encoded in the element's class (e.g. "star-rating Three") —
     # discovery picks `::attr(class)`, then we shape the value to the word.
-    rating: str = ys.Rating(description="Star rating in the element's class attribute, e.g. class='star-rating Three'")
+    rating: str = ys.Rating(description='Star rating, expressed as a word (e.g. "Three")')
 
     @field_validator('rating', mode='after')
     @classmethod

--- a/examples/discovery_demo.py
+++ b/examples/discovery_demo.py
@@ -1,0 +1,75 @@
+"""Keyless live DISCOVERY via the Claude Agent SDK — no provider API key required.
+
+Yosoi can drive its selector-discovery LLM through subscription-backed agent CLIs (the
+Claude Agent SDK / Claude Code, or OpenCode) instead of a per-token API key (CAS-28).
+This runs discovery from scratch (``force=True``) — the LLM analyses the live HTML, Yosoi
+verifies each selector against the DOM, then extracts and caches the result so future runs
+replay deterministically with no LLM (see ``examples/replay_demo.py``).
+
+Auth: uses the ambient Claude Code session — no key in the environment is needed, just a
+working ``claude`` CLI / ``claude_agent_sdk`` install.
+
+Run:
+    uv run python examples/discovery_demo.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import yosoi as ys
+
+_MODEL = ys.claude_sdk('claude-sonnet-4-5')
+
+
+class CatalogProduct(ys.Contract):
+    """A qscrape.dev L1 catalog item (static HTML)."""
+
+    name: str | None = ys.Title(default=None, description='Product name')
+    price: str | None = ys.Field(default=None, description='Product price')
+
+
+class RedditPost(ys.Contract):
+    """A reddit post / comment (JS-rendered)."""
+
+    author: str | None = ys.Author(default=None, description='Username of the poster')
+    title: str | None = ys.Title(default=None, description='Post title')
+    score: str | None = ys.Field(default=None, description='Post or comment score')
+
+
+class MapsBusiness(ys.Contract):
+    """A Google Maps business result (JS-rendered)."""
+
+    business_name: str | None = ys.Title(default=None, description='Business name')
+    phone: str | None = ys.Field(default=None, description='Phone number')
+
+
+# (contract, url, fetcher_type). qscrape L1 is static (fast); reddit/maps need a browser.
+_TARGETS = [
+    (CatalogProduct, 'https://qscrape.dev/l1/eshop/catalog/?cat=Forge%20%26%20Smithing', 'simple'),
+    (RedditPost, 'https://www.reddit.com/r/webscraping/comments/1tqajln/i_need_help/', 'headless'),
+    (MapsBusiness, 'https://www.google.com/maps/search/HomeWell+Care+Services+Plano%2C+TX/', 'headless'),
+]
+
+
+async def _discover(contract: type[ys.Contract], url: str, fetcher_type: str) -> None:
+    print(f'\n=== DISCOVER {contract.__name__} :: {url[:60]} (tier={fetcher_type}) ===', flush=True)
+    t = time.time()
+    try:
+        items = await ys.scrape(url, contract, model=_MODEL, force=True, fetcher_type=fetcher_type)
+    except Exception as e:  # demo: report per-target, don't abort the batch
+        print(f'  ✗ after {time.time() - t:.0f}s: {type(e).__name__}: {str(e)[:200]}', flush=True)
+        return
+    print(f'  ✓ discovered + extracted in {time.time() - t:.0f}s -> {len(items)} record(s)', flush=True)
+    for i, item in enumerate(items[:5], 1):
+        print(f'  {i:02d}. {item}', flush=True)
+
+
+async def main() -> None:
+    for contract, url, fetcher_type in _TARGETS:
+        await _discover(contract, url, fetcher_type)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/examples/js_fetcher_qscript_l2.py
+++ b/examples/js_fetcher_qscript_l2.py
@@ -36,8 +36,8 @@ class QscrapeL2NewsArticle(ys.Contract):
     headline: str = ys.Title(description='Main article headline')
     author: str = ys.Author(description='Article author or byline')
     date: str = ys.Datetime(description='Article publication date')
-    body_text: str = ys.BodyText(description='Full article body text, excluding navigation and related links')
-    related_content: list[str] = ys.Field(description='Related article links or sidebar recommendations')
+    body_text: str = ys.BodyText(description='Full article body text')
+    related_content: list[str] = ys.Field(description='Related or recommended article links')
 
 
 async def main() -> None:

--- a/examples/opencode_example.py
+++ b/examples/opencode_example.py
@@ -42,7 +42,7 @@ class Book(ys.Contract):
     # string e.g. "star-rating Three". CSS can't sub-select one class token,
     # so we shape the value here — extraction's job is the attribute, the
     # contract's job is the meaning.
-    rating: str = ys.Rating(description="Star rating in the element's class attribute, e.g. class='star-rating Three'")
+    rating: str = ys.Rating(description='Star rating, expressed as a word (e.g. "Three")')
 
     @field_validator('rating', mode='after')
     @classmethod

--- a/examples/reddit_comments_contract.py
+++ b/examples/reddit_comments_contract.py
@@ -56,11 +56,9 @@ class RedditPost(ys.Contract):
         default=None, description='Stable Reddit post id from the post element or canonical URL'
     )
     subreddit: str | None = ys.Field(default=None, description='Subreddit name, preferably the r/... prefixed value')
-    author: str | None = ys.Author(default=None, description='Original poster username from the post header')
+    author: str | None = ys.Author(default=None, description='Original poster username')
     title: str | None = ys.Title(default=None, description='Main Reddit post title')
-    body: str | None = ys.BodyText(
-        default=None, description='Original post body text, excluding comments and sidebar text'
-    )
+    body: str | None = ys.BodyText(default=None, description='Original post body text, excluding comments')
     score: int | None = ys.Field(default=None, description='Post score or upvote count as a non-negative integer')
     comment_count: int | None = ys.Field(default=None, description='Total comment count as a non-negative integer')
 

--- a/examples/replay_demo.py
+++ b/examples/replay_demo.py
@@ -1,0 +1,89 @@
+"""Deterministic, no-LLM REPLAY against cached selectors — Google Maps, reddit, qscrape.
+
+Yosoi's "discover once, scrape forever" promise: once selectors + a DOM-stability recipe
+(A3Node) are cached for a domain, a repeat visit replays them with **no LLM in the loop**.
+This example proves that — it never constructs a live model call; it fetches each live page
+and extracts with the per-domain cached selectors in ``.yosoi/selectors/``.
+
+Prerequisite: the three domains must already have cached selectors (run discovery once, or
+use a checked-out ``.yosoi/`` cache). Discovery itself (the LLM step) is a separate path —
+see ``examples/reddit_comments_contract.py`` — and needs a provider API key.
+
+Run:
+    uv run python examples/replay_demo.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import yosoi as ys
+
+# A model is constructed but NEVER called on a cache hit (force=False + skip_verification).
+# Any constructible spec works; no API key is needed because no request is made.
+_REPLAY_MODEL = 'groq:llama-3.3-70b-versatile'
+
+
+class Product(ys.Contract):
+    """qscrape.dev L2 e-shop item (React-rendered)."""
+
+    name: str | None = ys.Title(default=None, description='Product name')
+    price: str | None = ys.Field(default=None, description='Product price')
+
+
+class MapsBusiness(ys.Contract):
+    """A Google Maps business result."""
+
+    business_name: str | None = ys.Title(default=None, description='Business name')
+    rating: str | None = ys.Field(default=None, description='Average review rating')
+    phone: str | None = ys.Field(default=None, description='Phone number')
+
+
+class RedditPost(ys.Contract):
+    """Thread-level metadata from a reddit post."""
+
+    post_id: str | None = ys.Field(default=None, description='Stable post id')
+    subreddit: str | None = ys.Field(default=None, description='Subreddit name')
+    author: str | None = ys.Author(default=None, description='Original poster username')
+    title: str | None = ys.Title(default=None, description='Post title')
+    score: int | None = ys.Field(default=None, description='Post score')
+
+
+# (contract, url, fetcher_type) — urls/tiers mirror the cached snapshots.
+_TARGETS = [
+    (Product, 'http://qscrape.dev/l2/eshop/', 'headless'),
+    (RedditPost, 'https://www.reddit.com/r/webscraping/comments/1tqajln/i_need_help/', 'headless'),
+    (
+        MapsBusiness,
+        'https://www.google.com/maps/search/HomeWell+Care+Services+Plano%2C+TX/',
+        'headless',
+    ),
+]
+
+
+async def _replay(contract: type[ys.Contract], url: str, fetcher_type: str) -> None:
+    print(f'\n=== REPLAY {contract.__name__} :: {url[:70]} (tier={fetcher_type}) ===')
+    try:
+        items = await ys.scrape(
+            url,
+            contract,
+            model=_REPLAY_MODEL,
+            force=False,  # use cached selectors — no discovery
+            skip_verification=True,  # deterministic extract only — no LLM re-verify
+            fetcher_type=fetcher_type,
+        )
+    except Exception as e:  # demo: report per-target, don't abort the batch
+        print(f'  ✗ {type(e).__name__}: {str(e)[:200]}')
+        return
+    print(f'  ✓ {len(items)} record(s)')
+    for i, item in enumerate(items[:3], 1):
+        print(f'  {i:02d}. {item}')
+
+
+async def main() -> None:
+    for contract, url, fetcher_type in _TARGETS:
+        await _replay(contract, url, fetcher_type)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/benchmarks/fixtures.py
+++ b/tests/benchmarks/fixtures.py
@@ -35,7 +35,7 @@ class BookContract(Contract):
 
     title: str = ys.Title()
     price: float = ys.Price()
-    rating: str = ys.Field(description='Star rating, encoded in the class attribute')
+    rating: str = ys.Field(description='Star rating, expressed as a word (e.g. "Three")')
 
 
 class ArticleContract(Contract):

--- a/tests/unit/core/cleaning/test_cleaner.py
+++ b/tests/unit/core/cleaning/test_cleaner.py
@@ -113,6 +113,15 @@ def test_clean_html_removes_ad_class(cleaner):
     assert 'advertisement' not in result
 
 
+def test_clean_html_keeps_substring_ad_class(cleaner):
+    """Regression: the [class*='ad-'] substring matcher was removed — it nuked legit
+    nodes like 'road-map'/'bread-crumb' (they contain 'ad-'). Such content survives now."""
+    html = '<html><body><main><p>Real</p><div class="road-map">keep me</div></main></body></html>'
+    result = cleaner.clean_html(html)
+    assert 'road-map' in result
+    assert 'keep me' in result
+
+
 def test_clean_html_preserves_main_content(sample_html, cleaner):
     result = cleaner.clean_html(sample_html)
     assert 'Main Story' in result
@@ -442,16 +451,19 @@ def test_clean_html_removes_ad_class_exact(cleaner):
     assert 'Ad content' not in result
 
 
-def test_clean_html_removes_useful_links(cleaner):
+def test_clean_html_preserves_useful_links(cleaner):
+    """Content-bearing classes are NOT stripped — a contract may target them
+    (e.g. ys.RelatedContent), and cleaning runs before discovery/verification."""
     html = '<html><body><main><p>Content</p><div class="useful-links">Links</div></main></body></html>'
     result = cleaner.clean_html(html)
-    assert 'useful-links' not in result
+    assert 'useful-links' in result
 
 
-def test_clean_html_removes_related_posts(cleaner):
+def test_clean_html_preserves_related_posts(cleaner):
+    """`.related-posts` is real content (cf. ys.RelatedContent), so it must survive cleaning."""
     html = '<html><body><main><article><p>Content</p></article><div class="related-posts">More posts</div></main></body></html>'
     result = cleaner.clean_html(html)
-    assert 'related-posts' not in result
+    assert 'related-posts' in result
 
 
 def test_clean_html_removes_widget_class(cleaner):

--- a/tests/unit/core/fetcher/test_dom_replay.py
+++ b/tests/unit/core/fetcher/test_dom_replay.py
@@ -14,6 +14,7 @@ from yosoi.core.fetcher.dom.flows import WaitForDOMStable
 from yosoi.core.fetcher.dom.loader import _CLICK_KINDS, _SCROLL_KIND, DOMLoader
 from yosoi.core.fetcher.dom.tree.actions import ClickTrigger, Scroll
 from yosoi.core.fetcher.dom.tree.conditions import HasTrigger
+from yosoi.models.selectors import SelectorEntry
 from yosoi.storage.a3node import ActRecord
 
 
@@ -115,6 +116,31 @@ async def test_replay_reports_failure_when_no_content(mocker: MockerFixture):
 
     result = await loader.replay(_FakeTab(), [ActRecord('load_more', 1)])
     assert result.success is False  # caller will fall back to a full probe
+
+
+async def test_replay_with_stored_target_skips_catalogue_probe(mocker: MockerFixture):
+    """The core CAS-94 property: an act with a concrete target replays by clicking that
+    target via build_flow directly — the legacy probe/_build_replay_action (catalogues)
+    path is never used."""
+    loader = DOMLoader()
+    mocker.patch('yosoi.core.fetcher.dom.loader.count_content', return_value=3)
+    mocker.patch.object(loader, '_capture_html', mocker.AsyncMock(return_value='<html>' + 'x' * 100 + '</html>'))
+    legacy = mocker.patch.object(loader, '_build_replay_action')
+    fake_flow = mocker.MagicMock()
+    fake_flow.run = mocker.AsyncMock()
+    flow_builder = mocker.patch('yosoi.core.fetcher.dom.loader.build_flow', return_value=fake_flow)
+    settle = mocker.MagicMock()
+    settle.run = mocker.AsyncMock()
+    mocker.patch('yosoi.core.fetcher.dom.loader.Flow', return_value=settle)
+
+    target = SelectorEntry(type='role', value='button', name='Load more', nth=0)
+    result = await loader.replay(_FakeTab(), [ActRecord('load_more', 2, target=target)])
+
+    assert flow_builder.called  # stored target clicked via build_flow
+    assert not legacy.called  # catalogue/probe path NOT used
+    assert fake_flow.run.await_count >= 1
+    assert [(a.kind, a.cycles) for a in result.acts] == [('load_more', 1)]
+    assert result.acts[0].target == target  # target carried through to the replayed recipe
 
 
 async def test_replay_drops_acts_that_did_nothing(mocker: MockerFixture):

--- a/tests/unit/core/fetcher/test_probes.py
+++ b/tests/unit/core/fetcher/test_probes.py
@@ -1,0 +1,101 @@
+"""Tests for DOM page-state probes (yosoi.core.fetcher.dom.probes)."""
+
+import pytest
+
+from yosoi.core.fetcher.dom.ax import AxTarget
+from yosoi.core.fetcher.dom.probes import (
+    DetectedTrigger,
+    TriggerKind,
+    detected_trigger_to_selector_entry,
+    probe_infinite_scroll,
+    selector_entry_to_detected_trigger,
+)
+
+
+class _ScrollTab:
+    """Minimal fake tab whose eval_js returns a fixed scrollability verdict."""
+
+    def __init__(self, scrollable: bool) -> None:
+        self._scrollable = scrollable
+        self.evals: list[str] = []
+
+    async def eval_js(self, script: str):
+        self.evals.append(script)
+        return self._scrollable
+
+
+class _NoEvalTab:
+    """Fake tab with no eval_js method — probe must degrade to None, not raise."""
+
+
+@pytest.mark.asyncio
+async def test_infinite_scroll_detected_when_page_is_scrollable():
+    trigger = await probe_infinite_scroll(_ScrollTab(scrollable=True), content_count=7)
+    assert trigger is not None
+    assert trigger.kind == TriggerKind.INFINITE_SCROLL
+
+
+@pytest.mark.asyncio
+async def test_no_infinite_scroll_when_page_not_scrollable():
+    assert await probe_infinite_scroll(_ScrollTab(scrollable=False), content_count=20) is None
+
+
+@pytest.mark.asyncio
+async def test_round_count_alone_does_not_trigger():
+    """Regression: content_count % 10 == 0 must NOT fire on a non-scrollable page."""
+    tab = _ScrollTab(scrollable=False)
+    assert await probe_infinite_scroll(tab, content_count=10) is None
+    # The verdict came from a real DOM probe, not from the count.
+    assert tab.evals
+
+
+@pytest.mark.asyncio
+async def test_no_content_skips_probe_entirely():
+    """With zero counted items there is nothing to grow, so don't even eval."""
+    tab = _ScrollTab(scrollable=True)
+    assert await probe_infinite_scroll(tab, content_count=0) is None
+    assert not tab.evals
+
+
+@pytest.mark.asyncio
+async def test_missing_eval_js_degrades_to_none():
+    assert await probe_infinite_scroll(_NoEvalTab(), content_count=12) is None
+
+
+# --- DetectedTrigger <-> SelectorEntry conversion (selector-level recipes, CAS-94) ----
+
+
+def test_ax_trigger_becomes_role_selector_entry():
+    trigger = DetectedTrigger(
+        TriggerKind.LOAD_MORE, 'ax:button', 'Load more', ax_target=AxTarget('button', 'Load more', 0)
+    )
+    entry = detected_trigger_to_selector_entry(trigger)
+    assert entry is not None
+    assert (entry.type, entry.value, entry.name, entry.nth) == ('role', 'button', 'Load more', 0)
+
+
+def test_css_selector_trigger_becomes_css_entry():
+    entry = detected_trigger_to_selector_entry(DetectedTrigger(TriggerKind.PAGINATION, 'a.next', 'next'))
+    assert entry is not None
+    assert (entry.type, entry.value) == ('css', 'a.next')
+
+
+def test_text_match_trigger_has_no_stable_target():
+    """A text-match load-more (selector='button') carries no replayable selector."""
+    assert detected_trigger_to_selector_entry(DetectedTrigger(TriggerKind.LOAD_MORE, 'button', 'load more')) is None
+    assert detected_trigger_to_selector_entry(DetectedTrigger(TriggerKind.PAGINATION, 'a[href]', 'next')) is None
+
+
+def test_role_entry_round_trips_to_clickable_trigger():
+    original = DetectedTrigger(TriggerKind.PAGINATION, 'ax:link', 'Next', ax_target=AxTarget('link', 'Next', 2))
+    entry = detected_trigger_to_selector_entry(original)
+    rebuilt = selector_entry_to_detected_trigger(TriggerKind.PAGINATION, entry)
+    assert rebuilt.ax_target == AxTarget('link', 'Next', 2)
+    assert rebuilt.kind == TriggerKind.PAGINATION
+
+
+def test_css_entry_round_trips_to_clickable_trigger():
+    entry = detected_trigger_to_selector_entry(DetectedTrigger(TriggerKind.ACCORDION, 'details:not([open])', ''))
+    rebuilt = selector_entry_to_detected_trigger(TriggerKind.ACCORDION, entry)
+    assert rebuilt.ax_target is None
+    assert rebuilt.selector == 'details:not([open])'

--- a/tests/unit/core/replay/test_runtime_acts.py
+++ b/tests/unit/core/replay/test_runtime_acts.py
@@ -204,6 +204,26 @@ async def test_eval_act_with_output_field_captures_result():
     assert result.extracted_actions == {'signals': {'has_alita': True, 'competitors': ['comm100']}}
 
 
+async def test_eval_act_with_output_field_captures_null_result():
+    """A producer EVAL that yields None is captured AS None, not silently dropped.
+
+    Regression: capture is gated on output_field alone. Dropping a null return would
+    omit the field entirely and read as success — unacceptable for a replay-grade
+    substrate where 'field present and null' differs from 'field never produced'.
+    """
+
+    class _NullTab(FakeTab):
+        async def eval_js(self, script):
+            self.calls.append(('eval_js', script))
+            return
+
+    plan = ReplayPlan(
+        nodes=[_node('probe', ReplayAct(kind=ActKind.EVAL, script='(() => null)()', output_field='signals'))]
+    )
+    result = await execute_plan(_NullTab(), plan)
+    assert result.extracted_actions == {'signals': None}
+
+
 async def test_eval_act_without_output_field_does_not_capture():
     """EVAL act without output_field leaves extracted_actions empty."""
     plan = ReplayPlan(nodes=[_node('probe', ReplayAct(kind=ActKind.EVAL, script='document.title'))])

--- a/tests/unit/core/replay/test_runtime_dispatch.py
+++ b/tests/unit/core/replay/test_runtime_dispatch.py
@@ -1,0 +1,69 @@
+"""The act dispatch table (`_EXECUTORS`) must stay in sync with `ActKind`.
+
+The replay runtime dispatches each act through a table keyed by ``ActKind``
+(CAS-87). This guards the one failure mode that table introduces: a newly added
+``ActKind`` silently having no executor — or an out-of-band eval kind (ys.python /
+ys.llm) being wrongly registered here instead of as a post-replay transform.
+
+If you add an in-tab browser act, register it in ``_EXECUTORS`` and drop it from
+``_DEFERRED_KINDS`` below. If you add an out-of-band eval kind, leave it deferred —
+it does not belong in this table (see the table's docstring in runtime.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from yosoi.core.replay.runtime import _EXECUTORS, ReplayExecutionError, _execute_once
+from yosoi.models.replay import ActKind, ReplayAct
+
+# Act kinds intentionally absent from _EXECUTORS because they run as post-execute_plan
+# transforms, not in-tab browser acts. Empty today; populated when an out-of-band eval
+# kind (ys.python / ys.llm / ys.wasm) lands in ActKind.
+_DEFERRED_KINDS: frozenset[ActKind] = frozenset()
+
+
+def test_every_act_kind_is_registered_or_explicitly_deferred():
+    """No ActKind may silently fall through: it is either dispatchable or deferred."""
+    missing = set(ActKind) - set(_EXECUTORS) - _DEFERRED_KINDS
+    assert not missing, (
+        f'ActKind(s) {sorted(k.value for k in missing)} have no executor and are not in '
+        '_DEFERRED_KINDS. Register an in-tab executor, or defer out-of-band evals.'
+    )
+
+
+def test_table_and_deferred_sets_are_disjoint():
+    """A kind cannot be both dispatchable and deferred."""
+    assert not (set(_EXECUTORS) & _DEFERRED_KINDS)
+
+
+def test_out_of_band_eval_kinds_are_never_registered_in_table():
+    """Out-of-band evals (EVAL_PYTHON / EVAL_WASM / EVAL_LLM) must NOT be in _EXECUTORS.
+
+    This is the real failure mode the table introduces, and the one the docstring policy
+    can't enforce: when such a kind is added to ``ActKind``, the path of least resistance
+    to a green build is to drop it into ``_EXECUTORS`` — the exact forbidden move, since
+    those run as post-``execute_plan`` transforms, not on the deterministic replay hot path.
+    ``EVAL`` (in-tab JS) is intentionally NOT matched — only the ``EVAL_<runtime>`` family.
+    Tautological today (no such kinds exist yet) and becomes load-bearing the moment one does.
+    """
+    misfiled = sorted(k for k in _EXECUTORS if k.name.startswith('EVAL_'))
+    assert not misfiled, (
+        f'out-of-band eval kind(s) {misfiled} are registered in _EXECUTORS; they must run '
+        'as post-execute_plan transforms, not in-tab acts. Remove them from the table.'
+    )
+
+
+@pytest.mark.asyncio
+async def test_deferred_kinds_fail_loud_not_silent():
+    """A deferred kind raises fail-fast rather than returning a silent None.
+
+    Skips cleanly while _DEFERRED_KINDS is empty; becomes a real assertion the moment
+    an out-of-band eval kind is added, proving the loud-default still holds for it.
+    """
+    if not _DEFERRED_KINDS:
+        pytest.skip('no deferred kinds yet')
+    for kind in _DEFERRED_KINDS:
+        act = ReplayAct.model_construct(kind=kind)
+        with pytest.raises(ReplayExecutionError, match='unsupported act kind'):
+            await _execute_once(object(), act)

--- a/tests/unit/storage/test_a3node.py
+++ b/tests/unit/storage/test_a3node.py
@@ -61,6 +61,47 @@ class TestRealA3NodeStorage:
         await real_storage.save('example.com', _acts('cookie'))  # different acts
         assert (await real_storage.load('example.com')).replay_count == 0
 
+    async def test_act_target_round_trips(self, real_storage):
+        """A concrete SelectorEntry target survives save -> load (format 2)."""
+        from yosoi.models.selectors import SelectorEntry
+        from yosoi.storage.a3node import ActRecord
+
+        target = SelectorEntry(type='role', value='button', name='Load more', nth=0)
+        await real_storage.save('example.com', [ActRecord('load_more', 3, target=target)])
+        node = await real_storage.load('example.com')
+        assert node is not None
+        assert node.acts[0].target == target
+
+    async def test_save_writes_format_version(self, real_storage):
+        import os
+
+        await real_storage.save('example.com', _acts('load_more'))
+        with open(real_storage._filepath('example.com'), encoding='utf-8') as f:
+            assert json.load(f)['format'] == 2
+        assert os.path.exists(real_storage._filepath('example.com'))
+
+    async def test_adding_target_preserves_replay_count(self, real_storage):
+        """Format-1 -> format-2 upgrade (same kind/cycles, target added) keeps stats."""
+        from yosoi.models.selectors import SelectorEntry
+        from yosoi.storage.a3node import ActRecord
+
+        await real_storage.save('example.com', [ActRecord('load_more', 3)])  # no target
+        await real_storage.record_replay('example.com')
+        await real_storage.record_replay('example.com')
+        target = SelectorEntry(type='role', value='button', name='Load more', nth=0)
+        await real_storage.save('example.com', [ActRecord('load_more', 3, target=target)])  # refined
+        assert (await real_storage.load('example.com')).replay_count == 2
+
+    async def test_legacy_record_without_target_loads(self, real_storage):
+        """A format-1 file on disk (no 'format', no 'target') still loads cleanly."""
+        path = real_storage._filepath('legacy.com')
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump({'domain': 'legacy.com', 'acts': [{'kind': 'load_more', 'cycles': 4}]}, f)
+        node = await real_storage.load('legacy.com')
+        assert node is not None
+        assert node.acts[0].kind == 'load_more'
+        assert node.acts[0].target is None
+
     async def test_save_oserror_does_not_raise(self, real_storage, mocker):
         mocker.patch(
             'yosoi.storage.a3node.atomic_write_json_async',

--- a/tests/unit/storage/test_strategy.py
+++ b/tests/unit/storage/test_strategy.py
@@ -42,6 +42,15 @@ class TestSave:
         assert strategy.fetcher == 'headless'
         assert strategy.selector_level == 'xpath'
 
+    async def test_save_higher_tier_selector_levels_round_trip(self, storage):
+        """Regression: attr/global_id/role/visual were silently dropped by a stale
+        VALID_SELECTOR_LEVELS subset; they must now persist (AX/role discovery, CAS-79)."""
+        for level in ('attr', 'global_id', 'role', 'visual'):
+            await storage.save('example.com', 'headless', selector_level=level)
+            strategy = await storage.load_strategy('example.com')
+            assert strategy is not None
+            assert strategy.selector_level == level
+
     async def test_save_invalid_selector_level_is_dropped(self, storage):
         await storage.save('example.com', 'headless', selector_level='not_a_level')
         strategy = await storage.load_strategy('example.com')

--- a/tests/unit/types/test_coercion_regressions.py
+++ b/tests/unit/types/test_coercion_regressions.py
@@ -1,0 +1,192 @@
+"""Regression tests for hard-coded-heuristic bugs in type coercion (CAS-94 cleanup).
+
+Each test pins a concrete input that the previous heuristic got wrong:
+- rating word-map matched via ``startswith`` ("tens of reviews" -> 10.0)
+- price zero-words matched as a substring ("free shipping over $50" -> 0.0)
+- url tracking prefix ``ref`` over-stripped ("reference=" / "ref_id=")
+- datetime label-stripping was English-only and could be mangled by a time colon
+"""
+
+from __future__ import annotations
+
+import datetime as dt_module
+
+import pytest
+from pydantic import ValidationError
+
+import yosoi as ys
+from yosoi.models.contract import Contract
+
+# --- rating: whole-word, not startswith -------------------------------------------
+
+
+def test_rating_tens_is_not_ten():
+    """'tens of reviews' must not match the word 'ten' -> 10.0."""
+
+    class C(Contract):
+        rating: float = ys.Rating(as_float=True, scale=10)
+
+    with pytest.raises(ValidationError):
+        C.model_validate({'rating': 'tens of reviews'})
+
+
+def test_rating_word_still_coerces():
+    """The legitimate word-rating path still works after the whole-word fix."""
+
+    class C(Contract):
+        rating: float = ys.Rating(as_float=True)
+
+    assert C.model_validate({'rating': 'Three stars'}).rating == 3.0
+
+
+def test_rating_word_map_is_overridable():
+    """Non-English worded ratings work via an overridable word_map (not English-only SSoT)."""
+
+    class C(Contract):
+        rating: float = ys.Rating(as_float=True, word_map={'trois': 3, 'cinq': 5})
+
+    assert C.model_validate({'rating': 'trois étoiles'}).rating == 3.0
+    assert C.model_validate({'rating': 'cinq'}).rating == 5.0
+
+
+def test_rating_word_map_cjk_matches_mid_string():
+    """A CJK word_map key matches even embedded in surrounding text (\\b doesn't fire on CJK)."""
+
+    class C(Contract):
+        rating: float = ys.Rating(as_float=True, word_map={'三': 3})
+
+    assert C.model_validate({'rating': '三つ星'}).rating == 3.0
+
+
+def test_rating_word_map_regex_metachar_does_not_raise():
+    """A word_map key with regex metacharacters must not raise re.error (was unescaped)."""
+
+    class C(Contract):
+        rating: float = ys.Rating(as_float=True, word_map={'(a)': 2})
+
+    with pytest.raises(ValidationError):  # cleanly fails, NOT an unhandled re.error
+        C.model_validate({'rating': 'three'})
+
+
+# --- price: zero-words only when no number is present ------------------------------
+
+
+def test_price_free_shipping_keeps_real_number():
+    """'free shipping over $50' has a real price -> 50.0, not 0.0."""
+
+    class C(Contract):
+        price: float = ys.Price()
+
+    assert C.model_validate({'price': 'free shipping over $50'}).price == 50.0
+
+
+def test_price_bare_free_still_zero():
+    """A bare 'Free' (no number) still coerces to 0.0."""
+
+    class C(Contract):
+        price: float = ys.Price()
+
+    assert C.model_validate({'price': 'Free'}).price == 0.0
+
+
+def test_price_zero_value_words_overridable():
+    """Non-English zero-price words work via an overridable list (not English-only SSoT)."""
+
+    class C(Contract):
+        price: float = ys.Price(zero_value_words=('無料', 'gratuit'))
+
+    assert C.model_validate({'price': '無料'}).price == 0.0
+    assert C.model_validate({'price': '無料です'}).price == 0.0  # CJK mid-string
+    assert C.model_validate({'price': 'gratuit'}).price == 0.0
+
+
+# --- url: exact-key vs prefix tracking match --------------------------------------
+
+
+def test_url_ref_strips_exact_key_only():
+    """'ref' strips ref= but never reference= / ref_id= (was an over-broad startswith)."""
+
+    class C(Contract):
+        url: str = ys.Url()
+
+    result = C.model_validate({'url': 'https://example.com/p?ref=twitter&reference=42&ref_id=7'})
+    assert 'ref=twitter' not in result.url
+    assert 'reference=42' in result.url
+    assert 'ref_id=7' in result.url
+
+
+def test_url_utm_prefix_still_stripped():
+    """utm_ remains a prefix match (utm_source, utm_campaign, ...)."""
+
+    class C(Contract):
+        url: str = ys.Url()
+
+    result = C.model_validate({'url': 'https://example.com/p?utm_campaign=x&keep=1'})
+    assert 'utm_campaign' not in result.url
+    assert 'keep=1' in result.url
+
+
+# --- datetime: language-agnostic label strip, no over-strip ------------------------
+
+
+def test_datetime_non_english_label_stripped():
+    """A labelled date in any language parses (dateparser returns None on the raw label)."""
+
+    class C(Contract):
+        dt: str = ys.Datetime()
+
+    result = C.model_validate({'dt': 'Veröffentlicht: 2020-01-05'})
+    assert result.dt.startswith('2020-01-05')
+
+
+def test_datetime_english_label_still_stripped():
+    """The original English 'Label:' behaviour is preserved by the generic strip."""
+
+    class C(Contract):
+        dt: str = ys.Datetime()
+
+    result = C.model_validate({'dt': 'Published: 2020-01-05'})
+    assert result.dt.startswith('2020-01-05')
+
+
+def test_datetime_time_colon_not_mangled():
+    """A date containing a time must not be eaten by the leading-label strip."""
+
+    class C(Contract):
+        dt: dt_module.datetime = ys.Datetime(as_iso=False)
+
+    result = C.model_validate({'dt': 'Jan 5 2020 10:30'})
+    assert result.dt.hour == 10
+    assert result.dt.minute == 30
+
+
+def test_datetime_posted_on_default_still_works():
+    """The no-colon 'posted on' idiom remains a working default."""
+
+    class C(Contract):
+        dt: str = ys.Datetime()
+
+    result = C.model_validate({'dt': 'Posted on March 3, 2021'})
+    assert result.dt.startswith('2021-03-03')
+
+
+def test_datetime_strip_prefixes_overridable():
+    """The no-colon idiom list is an overridable default, not the source of truth."""
+
+    class C(Contract):
+        dt: str = ys.Datetime(strip_prefixes=('veröffentlicht am',))
+
+    result = C.model_validate({'dt': 'veröffentlicht am 5 January 2020'})
+    assert result.dt.startswith('2020-01-05')
+
+
+def test_datetime_month_label_is_not_stripped_into_backfill():
+    """Regression: a bare month/season before a colon ('March: 2020') must NOT be
+    stripped to a partial date that dateparser silently backfills from today — the
+    label-strip skips date-word labels, so this fails loudly instead of corrupting."""
+
+    class C(Contract):
+        dt: str = ys.Datetime()
+
+    with pytest.raises(ValidationError):
+        C.model_validate({'dt': 'March: 2020'})

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -16,7 +16,18 @@ from yosoi.utils.files import (
     get_tracking_path,
     init_yosoi,
     is_initialized,
+    safe_domain,
 )
+
+
+def test_safe_domain_replaces_separators():
+    assert safe_domain('finance.yahoo.com') == 'finance_yahoo_com'
+
+
+def test_safe_domain_strips_port_and_path_separators():
+    """The single source of truth handles ':' and '/' too, so port/path-bearing
+    domains map to one stable filename across every store (was the drift)."""
+    assert safe_domain('localhost:8080/app') == 'localhost_8080_app'
 
 
 def test_get_project_root(monkeypatch, tmp_path):

--- a/tests/unit/utils/test_urls.py
+++ b/tests/unit/utils/test_urls.py
@@ -4,7 +4,24 @@ import json
 
 import pytest
 
-from yosoi.utils.urls import load_urls_from_file
+from yosoi.utils.urls import extract_domain, load_urls_from_file
+
+
+class TestExtractDomain:
+    def test_strips_www_and_lowercases(self):
+        assert extract_domain('https://WWW.Example.com/path') == 'example.com'
+
+    def test_mixed_case_and_port_map_to_same_key(self):
+        """Regression: mixed-case host + port must not fork the per-domain cache."""
+        a = extract_domain('https://Example.com:8080/x')
+        b = extract_domain('https://example.com/y')
+        assert a == b == 'example.com'
+
+    def test_keeps_non_www_subdomain(self):
+        assert extract_domain('https://maps.google.com/maps') == 'maps.google.com'
+
+    def test_unparseable_returns_unknown(self):
+        assert extract_domain('not a url') == 'unknown'
 
 
 class TestLoadUrlsFromFile:

--- a/yosoi/core/cleaning/cleaner.py
+++ b/yosoi/core/cleaning/cleaner.py
@@ -75,21 +75,15 @@ class HTMLCleaner:
         for tag in tree.xpath('.//header | .//nav | .//footer'):
             _drop(tag)
 
-        # Step 3: Remove sidebars, widgets, ads (always enabled)
-        for selector in [
-            '.sidebar',
-            '.widget',
-            '#sidebar',
-            '.advertisement',
-            '.ad',
-            '[class*="ad-"]',
-            '[id*="ad-"]',
-            '.related-posts',
-            '.useful-links',
-        ]:
+        # Step 3: Remove common chrome/ad boilerplate. Deliberately conservative —
+        # NO substring matchers ([class*="ad-"] also nuked legit nodes like "bread-crumb"
+        # or "road-map"), and NO content-bearing class guesses (.related-posts /
+        # .useful-links): those can be exactly what a contract targets (e.g. ys.RelatedContent),
+        # and this cleaning runs *before* discovery and selector verification.
+        for selector in ['.sidebar', '#sidebar', '.widget', '.advertisement', '.ad']:
             for element in tree.cssselect(selector):
                 _drop(element)
-        self.console.print('  ↻ Removed sidebars/widgets/ads')
+        self.console.print('  ↻ Removed sidebar/widget/ad boilerplate')
 
         # Step 4: Get body or main content
         body = tree.find('.//body')

--- a/yosoi/core/discovery/orchestrator.py
+++ b/yosoi/core/discovery/orchestrator.py
@@ -403,8 +403,8 @@ class DiscoveryOrchestrator:
                 {
                     'field_name': 'root',
                     'field_description': (
-                        'Selector for the repeating wrapper element that contains one complete item '
-                        '(e.g., .product-card, article.listing). '
+                        'Selector for the repeating wrapper element that contains one complete item — '
+                        'the smallest element that wraps exactly one complete item. '
                         'Set to null for single-item pages.'
                     ),
                     'is_container': True,

--- a/yosoi/core/fetcher/base.py
+++ b/yosoi/core/fetcher/base.py
@@ -13,6 +13,10 @@ from yosoi.models.results import ContentMetadata, FetchResult
 if TYPE_CHECKING:
     from yosoi.models.download import DownloadSpec
 
+# Status codes that signal a hard anti-bot block and trigger fetch-tier escalation.
+# Single source of truth — was duplicated as a list here and a tuple in waterfall.py.
+HARD_BLOCK_STATUS = frozenset({403, 429, 503})
+
 
 class JSDetectionResult(BaseModel, frozen=True):
     """Result of JavaScript framework detection."""
@@ -376,7 +380,7 @@ class HTMLFetcher(ABC):
         headers_lower: dict[str, str] = {k.lower(): v for k, v in (headers or {}).items()}
 
         # Hard-block status codes — enrich with header context and return immediately
-        if status_code in [403, 429, 503]:
+        if status_code in HARD_BLOCK_STATUS:
             return True, self._enrich_with_header_context([f'HTTP {status_code}'], headers_lower)
 
         # cf-mitigated is a definitive Cloudflare block signal on any status code

--- a/yosoi/core/fetcher/dom/catalogues.py
+++ b/yosoi/core/fetcher/dom/catalogues.py
@@ -3,6 +3,14 @@
 Pure data — no logic. Import from here rather than defining inline so
 patterns are easy to extend without touching any logic files.
 
+These lists are a cold-start SEED and a fallback, NOT the source of truth
+(CAS-94). They are English- and convention-biased on purpose: discovery only
+consults them on the first probe of a domain. A successful probe persists the
+concrete winning target (a :class:`~yosoi.models.selectors.SelectorEntry`) into
+the A3Node recipe, so replay clicks that target directly and never re-reads
+these catalogues. A domain whose language or markup these lists don't cover
+therefore degrades to one extra probe, never to a hard failure.
+
 FUTURE: teach the discovery agent to propose or generate these catalogues,
 using this module as examples instead of relying on hand-maintained lists.
 """

--- a/yosoi/core/fetcher/dom/loader.py
+++ b/yosoi/core/fetcher/dom/loader.py
@@ -16,14 +16,16 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from rich.console import Console
+from voidcrawl.actions import Flow
 
 from yosoi.core.fetcher.dom.catalogues import CONTENT_SELECTOR
-from yosoi.core.fetcher.dom.flows import WaitForDOMStable
-from yosoi.core.fetcher.dom.probes import TriggerKind, count_content
+from yosoi.core.fetcher.dom.flows import WaitForDOMStable, build_flow
+from yosoi.core.fetcher.dom.probes import TriggerKind, count_content, selector_entry_to_detected_trigger
 from yosoi.core.fetcher.dom.tree.actions import ClickTrigger, Scroll
 from yosoi.core.fetcher.dom.tree.conditions import HasTrigger
 from yosoi.core.fetcher.dom.tree.default import build_default_tree
 from yosoi.core.fetcher.dom.tree.nodes import Status
+from yosoi.models.selectors import SelectorEntry
 from yosoi.storage.a3node import ActRecord
 
 # Trigger kinds that appear in a stored recipe (the ones that carry an ActionLog).
@@ -143,7 +145,7 @@ class DOMLoader:
 
         # Build both legacy action_log and structured acts list from the same source
         action_log = [{'kind': log.kind, 'cycles': log.cycles} for log in logs if log.cycles > 0]
-        acts = [ActRecord(kind=log.kind, cycles=log.cycles) for log in logs if log.cycles > 0]
+        acts = [ActRecord(kind=log.kind, cycles=log.cycles, target=log.target) for log in logs if log.cycles > 0]
 
         return LoadResult(
             success=True,
@@ -186,17 +188,30 @@ class DOMLoader:
 
         executed: list[ActRecord] = []
         for act in acts:
+            # Selector-level replay: a stored concrete target is clicked directly, so the
+            # hand-maintained discovery catalogues never run on the replay hot path (CAS-94).
+            if act.target is not None and act.kind in _CLICK_KINDS:
+                cycles = await self._replay_target(tab, act.kind, act.target, stable)
+                if cycles > 0:
+                    executed.append(ActRecord(kind=act.kind, cycles=cycles, target=act.target))
+                    self._log(f'replay: {act.kind} ran {cycles} cycle(s) via stored target')
+                continue
+
+            # Fallback path: scroll acts, or a click act with no stored target (a format-1
+            # recipe or a text-match act) — re-probe via the catalogues seed.
             built = self._build_replay_action(act.kind, stable)
             if built is None:
                 self._log(f'replay: skipping unsupported act kind {act.kind!r}')
                 continue
+            if act.target is None and act.kind in _CLICK_KINDS:
+                self._log(f'replay: {act.kind} has no stored target — falling back to probe')
             condition, action = built
             # Populate last_trigger for ClickTrigger; Scroll ignores it. A missing
             # trigger makes ClickTrigger a no-op (cycles stays 0), which we skip.
             await condition.tick(tab)
             await action.tick(tab)
             if action.log.cycles > 0:
-                executed.append(ActRecord(kind=act.kind, cycles=action.log.cycles))
+                executed.append(ActRecord(kind=act.kind, cycles=action.log.cycles, target=act.target))
                 self._log(f'replay: {act.kind} ran {action.log.cycles} cycle(s)')
 
         html = await self._capture_html(tab)
@@ -229,6 +244,31 @@ class DOMLoader:
             condition = HasTrigger(TriggerKind(kind), self._content_selector)
             return condition, ClickTrigger(condition, stable, self._max_click_cycles)
         return None
+
+    async def _replay_target(self, tab: Any, kind: str, target: SelectorEntry, stable: WaitForDOMStable) -> int:
+        """Replay one click act against its stored target — no probe, no catalogues.
+
+        Rebuilds a DetectedTrigger from the stored ``SelectorEntry`` and clicks it in a
+        growth loop, stopping once content stops growing. Returns the executed cycle
+        count (0 means the target produced no growth, so the caller drops the act and a
+        higher layer can fall back to a full probe).
+        """
+        trigger = selector_entry_to_detected_trigger(TriggerKind(kind), target)
+        cycles = 0
+        for _ in range(self._max_click_cycles):
+            prev = await count_content(tab, self._content_selector)
+            flow = build_flow(trigger, stable)
+            if flow is None:
+                break
+            await flow.run(tab)
+            cycles += 1
+            new = await count_content(tab, self._content_selector)
+            self._log(f'replay-target [{kind}]: {prev} → {new} items')
+            if new <= prev:
+                break
+        # Final settle so late-rendered content is present before HTML capture.
+        await Flow([stable]).run(tab)
+        return cycles
 
     async def _capture_html(self, tab: Any) -> str | None:
         """Capture full page HTML after loading is complete."""

--- a/yosoi/core/fetcher/dom/probes.py
+++ b/yosoi/core/fetcher/dom/probes.py
@@ -27,6 +27,7 @@ from yosoi.core.fetcher.dom.catalogues import (
     POPUP_SELECTORS,
     TAB_SELECTOR,
 )
+from yosoi.models.selectors import SelectorEntry
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,35 @@ class DetectedTrigger:
     selector: str
     label: str
     ax_target: AxTarget | None = None
+
+
+# Selector sentinels that are NOT stable, replayable targets — they drive a JS
+# text-match click or a generic scroll, so there is nothing concrete to persist.
+_UNSTABLE_SELECTORS = frozenset({'button', 'a[href]', 'body'})
+
+
+def detected_trigger_to_selector_entry(trigger: DetectedTrigger) -> SelectorEntry | None:
+    """Convert a freshly-probed trigger into a durable, replayable target.
+
+    Returns a ``role`` SelectorEntry for an AX-resolved trigger, a ``css`` SelectorEntry
+    for a concrete-selector trigger, or ``None`` for text-match/scroll triggers (those
+    carry no stable selector, so replay re-probes them via the catalogues seed).
+    """
+    ax = trigger.ax_target
+    if ax is not None and ax.name:
+        return SelectorEntry(type='role', value=ax.role, name=ax.name, nth=ax.nth)
+    sel = trigger.selector
+    if sel and not sel.startswith('ax:') and sel not in _UNSTABLE_SELECTORS:
+        return SelectorEntry(type='css', value=sel)
+    return None
+
+
+def selector_entry_to_detected_trigger(kind: TriggerKind, entry: SelectorEntry) -> DetectedTrigger:
+    """Rebuild a DetectedTrigger from a stored target so replay can act WITHOUT probing."""
+    if entry.type == 'role':
+        ax = AxTarget(role=entry.value, name=entry.name or '', nth=entry.nth or 0)
+        return DetectedTrigger(kind=kind, selector=f'ax:{entry.value}', label=entry.name or '', ax_target=ax)
+    return DetectedTrigger(kind=kind, selector=entry.value, label='')
 
 
 async def capture_ax_snapshot(tab: Any) -> AxSnapshot | None:
@@ -208,9 +238,31 @@ async def probe_pagination(tab: Any) -> DetectedTrigger | None:
     return None
 
 
+# Generic scrollability probe: does the page extend meaningfully below the viewport?
+# A real DOM fact (not a count heuristic) that means scrolling could reveal more content.
+_SCROLLABLE_JS = (
+    '(() => { const d = document.documentElement, b = document.body;'
+    ' const h = Math.max(d ? d.scrollHeight : 0, b ? b.scrollHeight : 0);'
+    ' return h - window.innerHeight > 100; })()'
+)
+
+
 async def probe_infinite_scroll(tab: Any, content_count: int) -> DetectedTrigger | None:
-    """Detect infinite scroll by checking if content count is a round number."""
-    if content_count > 0 and content_count % 10 == 0:
+    """Detect infinite scroll when the page is genuinely scrollable.
+
+    The signal is a real DOM fact — the page extends meaningfully below the viewport —
+    rather than the old ``content_count % 10`` guess (which false-fired on any page with
+    a round item count and missed feeds of 7 or 13). The Scroll action self-terminates
+    once scrolling stops growing content, so a false positive costs one bounded cycle.
+    """
+    if content_count <= 0:
+        return None
+    try:
+        scrollable = await tab.eval_js(_SCROLLABLE_JS)
+    except (RuntimeError, OSError, ValueError, AttributeError, TypeError) as exc:
+        logger.debug('probe_infinite_scroll eval failed: %s', exc)
+        return None
+    if scrollable:
         return DetectedTrigger(TriggerKind.INFINITE_SCROLL, 'body', 'scroll to bottom')
     return None
 

--- a/yosoi/core/fetcher/dom/tree/actions.py
+++ b/yosoi/core/fetcher/dom/tree/actions.py
@@ -15,9 +15,10 @@ from typing import Any
 from voidcrawl.actions import Flow, ScrollTo
 
 from yosoi.core.fetcher.dom.flows import WaitForDOMStable, build_flow
-from yosoi.core.fetcher.dom.probes import count_content
+from yosoi.core.fetcher.dom.probes import count_content, detected_trigger_to_selector_entry
 from yosoi.core.fetcher.dom.tree.conditions import HasTrigger
 from yosoi.core.fetcher.dom.tree.nodes import Node, Status
+from yosoi.models.selectors import SelectorEntry
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +32,13 @@ class ActionLog:
     Attributes:
         kind: What type of action was taken.
         cycles: How many times the action was repeated.
+        target: The concrete winning selector for this action (for selector-level
+            replay), or None for scroll / text-match actions that carry no stable target.
     """
 
     kind: str
     cycles: int = 0
+    target: SelectorEntry | None = None
 
 
 class ClickClose(Node):
@@ -98,6 +102,11 @@ class ClickTrigger(Node):
         trigger = self._condition.last_trigger
         if trigger is None:
             return Status.FAILURE
+
+        # Record the concrete winning target once, so replay can click it directly
+        # instead of re-running the discovery catalogues (CAS-94).
+        if self.log.target is None:
+            self.log.target = detected_trigger_to_selector_entry(trigger)
 
         content_selector = self._condition._content_selector
 

--- a/yosoi/core/fetcher/voiddriver.py
+++ b/yosoi/core/fetcher/voiddriver.py
@@ -22,7 +22,6 @@ import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
-from urllib.parse import urlparse
 
 from rich.console import Console
 
@@ -36,6 +35,7 @@ from yosoi.models.results import FetchResult, JsOutputs
 from yosoi.storage.a3node import A3Node, A3NodeStorage, ActRecord
 from yosoi.utils import observability as obs
 from yosoi.utils.exceptions import BotDetectionError, DownloadError
+from yosoi.utils.urls import extract_domain
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +178,7 @@ class _VoidCrawlFetcher(HTMLFetcher):
         action_scripts: dict[str, str] | None = None,
         download_specs: dict[str, DownloadSpec] | None = None,
     ) -> FetchResult:
-        domain = urlparse(url).netloc.replace('www.', '')
+        domain = extract_domain(url)
         stored_node = self._a3node_cache.get(domain) if self._experimental_a3node else None
 
         js_outputs: JsOutputs | None = None

--- a/yosoi/core/fetcher/waterfall.py
+++ b/yosoi/core/fetcher/waterfall.py
@@ -26,17 +26,17 @@ from __future__ import annotations
 import logging
 import time
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
 
 import httpx
 from rich.console import Console
 
-from yosoi.core.fetcher.base import HTMLFetcher
+from yosoi.core.fetcher.base import HARD_BLOCK_STATUS, HTMLFetcher
 from yosoi.core.fetcher.simple import SimpleFetcher
 from yosoi.core.fetcher.voiddriver import HeadfulFetcher, HeadlessFetcher
 from yosoi.models.results import FetchResult
 from yosoi.storage.strategy import FetchStrategy, FetchStrategyStorage
 from yosoi.utils.exceptions import BotDetectionError
+from yosoi.utils.urls import extract_domain
 
 if TYPE_CHECKING:
     from yosoi.models.download import DownloadSpec
@@ -224,7 +224,7 @@ class JSFetcher(HTMLFetcher):
             headers = {k.lower(): v.lower() for k, v in r.headers.items()}
 
             # Hard block / bot gate status codes → Chrome required
-            if r.status_code in (403, 429, 503):
+            if r.status_code in HARD_BLOCK_STATUS:
                 return True
 
             # Thin content-length on an HTML page = likely a shell with no body
@@ -297,7 +297,7 @@ class JSFetcher(HTMLFetcher):
 
         """
         start_time = time.time()
-        domain = urlparse(url).netloc.replace('www.', '')
+        domain = extract_domain(url)
         cached_strategy = None if self._force else self._preferred_strategy(domain)
 
         if cached_strategy is not None:

--- a/yosoi/core/pipeline.py
+++ b/yosoi/core/pipeline.py
@@ -1762,7 +1762,10 @@ class Pipeline:
         level_dist = getattr(self, '_last_level_distribution', None)
         if not level_dist:
             return
-        order = ['css', 'xpath', 'regex', 'jsonld']
+        # Ascending by level so reversed() picks the highest tier that worked. Derived from
+        # the canonical SelectorLevel enum — must include attr/global_id/role/visual or a
+        # winning higher tier never gets cached (it would fall out of a stale literal list).
+        order = [level.name.lower() for level in sorted(SelectorLevel)]
         highest = next((level for level in reversed(order) if level_dist.get(level)), None)
         if highest is not None:
             await fetcher.update_selector_level(domain, highest)

--- a/yosoi/core/replay/runtime.py
+++ b/yosoi/core/replay/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -70,7 +71,11 @@ async def execute_plan(tab: Any, plan: ReplayPlan) -> ReplayResult:
             _fail(report, f'assess failed for {node.id}: {node.intent}')
 
         output = await _execute_act(tab, node.act, node.expect)
-        if node.act.output_field is not None and output is not None:
+        # Gate capture on output_field alone: only producer acts (EVAL/DOWNLOAD) set it,
+        # so this never captures a mutator's None. A producer that legitimately yields
+        # None (JS returning null, an empty projection) must be captured AS None — dropping
+        # it would silently omit the field and read as success on a replay-grade substrate.
+        if node.act.output_field is not None:
             captured[node.act.output_field] = output
 
         if not await _condition_holds(tab, node.expect):
@@ -108,30 +113,17 @@ async def _execute_act(tab: Any, act: ReplayAct, expect: ReplayCondition) -> Any
 
 
 async def _execute_once(tab: Any, act: ReplayAct) -> Any:
-    if act.kind == ActKind.NAVIGATE:
-        await _call(tab, 'goto', act.url)
-        return None
-    if act.kind == ActKind.CLICK:
-        await _click_first(tab, act.targets)
-        return None
-    if act.kind == ActKind.TYPE:
-        await _type_first(tab, act.targets, act.text or '')
-        return None
-    if act.kind == ActKind.SCROLL:
-        await _scroll(tab, act)
-        return None
-    if act.kind == ActKind.WAIT:
-        if act.dwell_ms:
-            await asyncio.sleep(act.dwell_ms / 1000)
-        return None
-    if act.kind == ActKind.EVAL:
-        return await _eval(tab, act.script or '')
-    if act.kind == ActKind.DOWNLOAD:
-        return await _download(tab, act)
-    if act.kind == ActKind.TELEPORT:
-        await _teleport(tab, act.metadata)
-        return None
-    raise ReplayExecutionError(f'unsupported act kind: {act.kind}')
+    """Dispatch a single act to its in-tab executor via :data:`_EXECUTORS`.
+
+    An act kind with no registered executor fails fast — the same loud default the
+    previous if-chain gave, now structural: a new ``ActKind`` cannot silently fall
+    through (see ``tests/unit/core/replay/test_runtime_dispatch.py``, which asserts
+    the table stays in sync with the enum).
+    """
+    executor = _EXECUTORS.get(act.kind)
+    if executor is None:
+        raise ReplayExecutionError(f'unsupported act kind: {act.kind}')
+    return await executor(tab, act)
 
 
 async def _download(tab: Any, act: ReplayAct) -> Any:
@@ -167,6 +159,71 @@ async def _download(tab: Any, act: ReplayAct) -> Any:
     except DownloadError as exc:
         raise ReplayExecutionError(str(exc)) from exc
     return result.value
+
+
+# --- Act executors -----------------------------------------------------------------
+# Each executor runs one act against a LIVE browser tab and returns either None (a
+# page-mutating act like click/navigate) or a value to capture into ``output_field``
+# (eval/download). The thin wrappers below adapt the existing helpers to the uniform
+# ``(tab, act) -> Any`` shape the dispatch table requires.
+
+
+async def _exec_navigate(tab: Any, act: ReplayAct) -> Any:
+    await _call(tab, 'goto', act.url)
+    return None
+
+
+async def _exec_click(tab: Any, act: ReplayAct) -> Any:
+    await _click_first(tab, act.targets)
+    return None
+
+
+async def _exec_type(tab: Any, act: ReplayAct) -> Any:
+    await _type_first(tab, act.targets, act.text or '')
+    return None
+
+
+async def _exec_scroll(tab: Any, act: ReplayAct) -> Any:
+    await _scroll(tab, act)
+    return None
+
+
+async def _exec_wait(tab: Any, act: ReplayAct) -> Any:
+    if act.dwell_ms:
+        await asyncio.sleep(act.dwell_ms / 1000)
+    return None
+
+
+async def _exec_eval(tab: Any, act: ReplayAct) -> Any:
+    return await _eval(tab, act.script or '')
+
+
+async def _exec_teleport(tab: Any, act: ReplayAct) -> Any:
+    await _teleport(tab, act.metadata)
+    return None
+
+
+# Dispatch table for in-tab, deterministic browser acts — the composition spine for a
+# per-domain replay program (CAS-87). New browser act kind → add an executor + one entry.
+#
+# DELIBERATELY browser-acts-only. Out-of-band evals do NOT belong here:
+#   * ys.python (ActKind.EVAL_PYTHON) runs in a Pyodide sandbox over already-extracted
+#     data — it has no live tab, so it is a post-``execute_plan`` transform, not an act.
+#   * ys.llm (ActKind.EVAL_LLM) is a non-deterministic model call — adding it here would
+#     put the LLM back on the replay hot path and break replay-grade determinism.
+#   * ys.wasm is a future codec behind ``_eval``, not a new kind.
+# Keeping this table deterministic and LLM-free is what lets the discovery layer be the
+# signal-driven brain without contaminating replay. See CAS-87 for the full decision.
+_EXECUTORS: dict[ActKind, Callable[[Any, ReplayAct], Awaitable[Any]]] = {
+    ActKind.NAVIGATE: _exec_navigate,
+    ActKind.CLICK: _exec_click,
+    ActKind.TYPE: _exec_type,
+    ActKind.SCROLL: _exec_scroll,
+    ActKind.WAIT: _exec_wait,
+    ActKind.EVAL: _exec_eval,
+    ActKind.DOWNLOAD: _download,
+    ActKind.TELEPORT: _exec_teleport,
+}
 
 
 async def _condition_holds(tab: Any, condition: ReplayCondition) -> bool:

--- a/yosoi/models/defaults.py
+++ b/yosoi/models/defaults.py
@@ -11,17 +11,17 @@ from yosoi.models.contract import Contract
 class NewsArticle(Contract):
     """Default contract matching the original 5-field behavior."""
 
-    headline: str = ys.Title(description='Main article title (h1/h2 in article, NOT navigation)')
-    author: str = ys.Author(description='Author name (author/byline classes or links)')
-    date: str = ys.Datetime(description='Publication date (time tags or date/published classes)')
-    body_text: str = ys.BodyText(description='Article paragraphs (p tags in article, NOT sidebars/ads)')
-    related_content: str = ys.RelatedContent(description='Related article links (aside/sidebar sections)')
+    headline: str = ys.Title(description='The main headline of the article')
+    author: str = ys.Author(description='The name of the article author or byline')
+    date: str = ys.Datetime(description='The publication date of the article')
+    body_text: str = ys.BodyText(description='The main body text of the article')
+    related_content: str = ys.RelatedContent(description='Links to related or recommended articles')
 
 
 class Video(Contract):
     """Contract for video pages (YouTube-style)."""
 
-    title: str = ys.Title(description='Video title (h1 or main heading)')
+    title: str = ys.Title(description='The title of the video')
     channel: str = ys.Author(description='Channel or creator name')
     duration: str = Field(description='Video duration (e.g. "10:32")')
     views: int | None = Field(description='View count')

--- a/yosoi/prompts/discovery.py
+++ b/yosoi/prompts/discovery.py
@@ -29,11 +29,10 @@ For each field provide:
 
 If the value lives in an ATTRIBUTE rather than visible text, target the
 attribute with a CSS `::attr(name)` pseudo-element so extraction returns the
-attribute string. Common cases: a rating encoded in a class
-(`p.star-rating::attr(class)`), a machine date (`time::attr(datetime)`), a
-price in microdata (`meta[itemprop="price"]::attr(content)`), or an input's
-`value`. Use `::attr(...)` whenever the matched element carries no useful
-text node."""
+attribute string — for example a value carried in a class token, a
+machine-readable date/time attribute, a microdata content attribute, or an
+input's `value`. Use `::attr(...)` whenever the matched element carries no
+useful text node."""
 
 _LEVEL_CSS_ONLY: Final = 'Use CSS selectors only (e.g. .class-name, #id, h1 > span).'
 
@@ -69,8 +68,8 @@ _HINT_DATA_QA: Final = 'Page uses data-qa/data-cy test attributes — they are s
 _CONTAINER_GUIDANCE: Final = (
     'If the page contains multiple repeating items (e.g., product cards, article listings, '
     'search results), also provide a `root` selector for the repeating wrapper element '
-    'that contains one complete item. This selector should match each individual item on the '
-    'page (e.g., `.product-card`, `article.listing`). '
+    'that contains one complete item — the smallest element that wraps exactly one complete '
+    'item and matches each item on the page. '
     'If the page shows a single item, set `root` to null.'
 )
 
@@ -78,10 +77,9 @@ _MULTI_ITEM_FIELD_GUIDANCE: Final = (
     'IMPORTANT — repeating-item scoping: if the HTML contains multiple repeating items '
     '(product cards, listings, search results, table rows), this field belongs to ONE item, '
     'so your selector MUST match the value *inside a single repeating item* and resolve once '
-    'per item. Do NOT target page-level chrome such as the page title/heading (e.g. a top-level '
-    '<h1>), site header, breadcrumbs, or navigation — even when the field is named "title" or '
-    '"heading", prefer the per-item element (e.g. the card\'s own heading link) over a page-wide '
-    'heading. When in doubt, scope the selector under the repeating item wrapper.'
+    'per item. Even when the field is named "title" or "heading", prefer the per-item element '
+    'over any page-level element that appears once for the whole page. When in doubt, scope the '
+    'selector under the repeating item wrapper.'
 )
 
 

--- a/yosoi/storage/a3node.py
+++ b/yosoi/storage/a3node.py
@@ -7,13 +7,14 @@ probe phase entirely and reaching page stability at significantly higher speed.
 
 Storage location: .yosoi/a3nodes/a3node_<domain>.json
 
-File format::
+File format (format 2)::
 
     {
+      "format": 2,
       "domain": "finance.yahoo.com",
       "acts": [
-        {"kind": "cookie", "cycles": 1},
-        {"kind": "load_more", "cycles": 7}
+        {"kind": "load_more", "cycles": 7,
+         "target": {"type": "role", "value": "button", "name": "Load more", "nth": 0}}
       ],
       "discovered_at": "2026-05-23T14:00:00",
       "replay_count": 3,
@@ -23,6 +24,14 @@ File format::
 ``acts`` is an ordered list — replay executes them in the stored order.
 An empty ``acts`` list means the domain was probed but needed no action.
 ``replay_count`` tracks how often the stored recipe was used successfully.
+
+``target`` (added in format 2) is the concrete winning selector — a serialised
+:class:`~yosoi.models.selectors.SelectorEntry` — so replay clicks it directly instead
+of re-running the discovery catalogues. The hand-maintained catalogues are only the
+cold-start *seed* and the fallback. An act with no ``target`` (a format-1 recipe, or a
+text-match act with no stable selector) falls back to a catalogue re-probe on replay.
+A missing ``format`` key is treated as format 1. Recipe identity for replay_count
+preservation is the ``(kind, cycles)`` sequence, so refining a target keeps the stats.
 """
 
 from __future__ import annotations
@@ -37,9 +46,24 @@ from typing import Any
 import aiofiles
 import aiofiles.os
 
-from yosoi.utils.files import atomic_write_json_async, init_yosoi
+from yosoi.models.selectors import SelectorEntry
+from yosoi.utils.files import atomic_write_json_async, init_yosoi, safe_domain
 
 logger = logging.getLogger(__name__)
+
+# On-disk recipe format. 1 = {kind, cycles} only; 2 = adds a concrete `target` per act
+# so replay skips the discovery catalogues. A file with no `format` key is format 1.
+_A3NODE_FORMAT = 2
+
+
+def _acts_shape(acts: list[dict[str, Any]]) -> list[tuple[object, object]]:
+    """Recipe identity for stat preservation: the (kind, cycles) sequence only.
+
+    Adding or refining a concrete ``target`` on an otherwise-identical recipe must NOT
+    reset ``replay_count`` — that is what makes the format-1 -> format-2 upgrade
+    non-destructive for battle-tested domains.
+    """
+    return [(a.get('kind'), a.get('cycles')) for a in acts]
 
 
 @dataclass
@@ -54,15 +78,21 @@ class ActRecord:
 
     kind: str
     cycles: int
+    target: SelectorEntry | None = None
 
     def to_dict(self) -> dict[str, object]:
         """Serialise to a plain dict for JSON storage."""
-        return {'kind': self.kind, 'cycles': self.cycles}
+        d: dict[str, object] = {'kind': self.kind, 'cycles': self.cycles}
+        if self.target is not None:
+            d['target'] = self.target.model_dump(exclude_none=True)
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> ActRecord:
-        """Deserialise from a plain dict."""
-        return cls(kind=str(d['kind']), cycles=int(d['cycles']))
+        """Deserialise from a plain dict (tolerates format-1 records with no target)."""
+        raw_target = d.get('target')
+        target = SelectorEntry.model_validate(raw_target) if raw_target else None
+        return cls(kind=str(d['kind']), cycles=int(d['cycles']), target=target)
 
 
 class A3NodeStorage:
@@ -112,13 +142,16 @@ class A3NodeStorage:
         filepath = self._filepath(domain)
         now = datetime.now().isoformat()
 
-        # Preserve replay stats when acts haven't changed
+        # Preserve replay stats when the recipe's (kind, cycles) shape is unchanged.
+        # Comparing shape (not the full dict) keeps replay_count across a target refinement
+        # and across the format-1 -> format-2 upgrade; a real kind/cycles change resets it.
         existing = await self._load_raw(domain)
         existing_acts = existing.get('acts', []) if existing else []
         new_acts_dicts = [a.to_dict() for a in acts]
-        same = existing_acts == new_acts_dicts
+        same = _acts_shape(existing_acts) == _acts_shape(new_acts_dicts)
 
         data: dict[str, object] = {
+            'format': _A3NODE_FORMAT,
             'domain': domain,
             'acts': new_acts_dicts,
             'discovered_at': existing.get('discovered_at', now) if existing else now,
@@ -241,7 +274,7 @@ class A3NodeStorage:
     # ------------------------------------------------------------------
 
     def _filepath(self, domain: str) -> str:
-        safe = domain.replace('.', '_').replace('/', '_').replace(':', '_')
+        safe = safe_domain(domain)
         return os.path.join(self._dir, f'a3node_{safe}.json')
 
     async def _load_raw(self, domain: str) -> dict[str, Any] | None:

--- a/yosoi/storage/discovery_strategy.py
+++ b/yosoi/storage/discovery_strategy.py
@@ -20,7 +20,7 @@ from typing import Literal
 import aiofiles
 import aiofiles.os
 
-from yosoi.utils.files import atomic_write_json_async, init_yosoi
+from yosoi.utils.files import atomic_write_json_async, init_yosoi, safe_domain
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,6 @@ class DiscoveryStrategyStorage:
         return None
 
     def _filepath(self, domain: str, contract_sig: str) -> str:
-        safe_domain = domain.replace('.', '_').replace('/', '_')
+        safe = safe_domain(domain)
         safe_sig = ''.join(c if c.isalnum() or c in ('-', '_') else '_' for c in contract_sig)
-        return os.path.join(self._dir, f'discovery_{safe_domain}__{safe_sig}.json')
+        return os.path.join(self._dir, f'discovery_{safe}__{safe_sig}.json')

--- a/yosoi/storage/js_scripts.py
+++ b/yosoi/storage/js_scripts.py
@@ -13,7 +13,7 @@ from typing import Any
 import aiofiles
 import aiofiles.os
 
-from yosoi.utils.files import atomic_write_json_async, init_yosoi
+from yosoi.utils.files import atomic_write_json_async, init_yosoi, safe_domain
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +78,8 @@ class JsScriptStorage:
         self._dir = str(init_yosoi(storage_dir))
 
     def _filepath(self, domain: str) -> str:
-        safe_domain = domain.replace('.', '_').replace('/', '_').replace(':', '_')
-        return os.path.join(self._dir, f'js_{safe_domain}.json')
+        safe = safe_domain(domain)
+        return os.path.join(self._dir, f'js_{safe}.json')
 
     async def load(self, domain: str) -> JsScriptRecord | None:
         """Return the stored record for *domain*, or None."""

--- a/yosoi/storage/persistence.py
+++ b/yosoi/storage/persistence.py
@@ -23,7 +23,8 @@ from yosoi.models.snapshot import (
     selector_dict_to_snapshot,
     snapshot_to_selector_dict,
 )
-from yosoi.utils.files import atomic_write_json_async, init_yosoi
+from yosoi.utils.files import atomic_write_json_async, init_yosoi, safe_domain
+from yosoi.utils.urls import extract_domain
 
 
 class SelectorStorage:
@@ -356,25 +357,8 @@ class SelectorStorage:
         return formatted
 
     def _extract_domain(self, url: str) -> str:
-        """Extract domain from URL.
-
-        Removes 'www.' prefix if present.
-
-        Args:
-            url: URL to extract domain from
-
-        Returns:
-            Domain name without 'www.' prefix, or 'unknown' if URL is invalid.
-
-        """
-        try:
-            parsed = urlparse(url)
-            domain = parsed.netloc
-            if domain.startswith('www.'):
-                domain = domain[4:]
-            return domain
-        except ValueError:
-            return 'unknown'
+        """Extract the normalized domain from a URL (single source of truth)."""
+        return extract_domain(url)
 
     def _get_filepath(self, domain: str) -> str:
         """Get filepath for a domain's selectors (always JSON).
@@ -398,8 +382,8 @@ class SelectorStorage:
             Full file path for the domain's selector file.
 
         """
-        safe_domain = domain.replace('.', '_').replace('/', '_')
-        return os.path.join(self.storage_dir, f'selectors_{safe_domain}.json')
+        safe = safe_domain(domain)
+        return os.path.join(self.storage_dir, f'selectors_{safe}.json')
 
     def _get_content_filepath(self, url: str, output_format: str = 'json', contract_sig: str | None = None) -> str:
         """Get filepath for a URL's extracted content.
@@ -432,10 +416,10 @@ class SelectorStorage:
         }
 
         parsed = urlparse(url)
-        domain = parsed.netloc.replace('www.', '')
-        safe_domain = domain.replace('.', '_').replace('/', '_')
+        domain = extract_domain(url)
+        safe = safe_domain(domain)
         ext = _EXTENSIONS.get(output_format, 'json')
-        domain_dir = os.path.join(self.content_dir, safe_domain)
+        domain_dir = os.path.join(self.content_dir, safe)
 
         if output_format in _ACCUMULATING:
             return os.path.join(domain_dir, f'results.{ext}')

--- a/yosoi/storage/strategy.py
+++ b/yosoi/storage/strategy.py
@@ -24,16 +24,21 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime
+from typing import get_args
 
 import aiofiles
 import aiofiles.os
 
-from yosoi.utils.files import atomic_write_json_async, init_yosoi
+from yosoi.models.selectors import SelectorKind
+from yosoi.utils.files import atomic_write_json_async, init_yosoi, safe_domain
 
 logger = logging.getLogger(__name__)
 
 VALID_FETCHERS = frozenset({'simple', 'headless', 'headful'})
-VALID_SELECTOR_LEVELS = frozenset({'css', 'xpath', 'regex', 'jsonld'})
+# Derived from the canonical SelectorKind union — must cover every level the discovery
+# pipeline can produce (css/xpath/regex/jsonld/attr/global_id/role/visual), or a winning
+# higher-tier strategy (e.g. role/attr from AX discovery) is silently dropped on save.
+VALID_SELECTOR_LEVELS = frozenset(get_args(SelectorKind))
 
 
 @dataclass(frozen=True)
@@ -176,5 +181,5 @@ class FetchStrategyStorage:
     # ------------------------------------------------------------------
 
     def _filepath(self, domain: str) -> str:
-        safe = domain.replace('.', '_').replace('/', '_')
+        safe = safe_domain(domain)
         return os.path.join(self._dir, f'fetch_{safe}.json')

--- a/yosoi/storage/tracking.py
+++ b/yosoi/storage/tracking.py
@@ -7,12 +7,12 @@ import asyncio
 import json
 import os
 from typing import Any
-from urllib.parse import urlparse
 
 import aiofiles
 from pydantic import BaseModel, Field
 
 from yosoi.utils.files import atomic_write_json, atomic_write_json_async, get_tracking_path
+from yosoi.utils.urls import extract_domain
 
 
 class DomainStats(BaseModel):
@@ -88,25 +88,8 @@ class LLMTracker:
         await atomic_write_json_async(self.tracking_file, data, ensure_ascii=False)
 
     def extract_domain(self, url: str) -> str:
-        """Extract domain from URL.
-
-        Removes 'www.' prefix if present.
-
-        Args:
-            url: URL to extract domain from
-
-        Returns:
-            Domain name without 'www.' prefix, or 'unknown' if URL is invalid.
-
-        """
-        try:
-            parsed = urlparse(url)
-            domain = parsed.netloc
-            if domain.startswith('www.'):
-                domain = domain[4:]
-            return domain
-        except ValueError:
-            return 'unknown'
+        """Extract the normalized domain from a URL (single source of truth)."""
+        return extract_domain(url)
 
     async def record_url(
         self,

--- a/yosoi/types/datetime.py
+++ b/yosoi/types/datetime.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import datetime as dt_module
+import re
 
 import dateparser
 
 from yosoi.types.registry import KIND_TEXT, CoercionConfig, SemanticRule, register_coercion
 
-_STRIP_PREFIXES = ('published:', 'updated:', 'posted on')
+# Language-agnostic "Label:" prefix (dateparser returns None on any labelled date, in any
+# language). Matches up to ~4 leading letter-words then a colon — a digit anywhere before
+# the colon breaks the match, so real dates with times ("Jan 5 2020 10:30") are never eaten.
+_LABEL_RE = re.compile(r'^(?:[^\W\d_]+\s+){0,3}[^\W\d_]+\s*[:：]\s*')
+
+# No-colon label idioms dateparser can't strip itself. A DEFAULT, not the SSoT: override
+# per field via ys.Datetime(strip_prefixes=(...)). Empty tuple disables it entirely.
+_DEFAULT_STRIP_PREFIXES = ('posted on',)
 
 
 @register_coercion(
@@ -18,6 +26,7 @@ _STRIP_PREFIXES = ('published:', 'updated:', 'posted on')
     assume_utc=True,
     past_only=False,
     as_iso=True,
+    strip_prefixes=_DEFAULT_STRIP_PREFIXES,
 )
 def Datetime(v: object, config: CoercionConfig, source_url: str | None = None) -> dt_module.datetime | str:
     """Configure a datetime field with timezone, tense, and format options.
@@ -34,8 +43,20 @@ def Datetime(v: object, config: CoercionConfig, source_url: str | None = None) -
 
     raw = str(v).strip()
 
+    # Strip a leading "Label:" segment in any language (dateparser can't) — but ONLY
+    # when the label is not itself a date word. Stripping a month/weekday/season
+    # ("March: 2020") would leave a partial date that dateparser silently backfills
+    # from today, turning a fail-fast into wrong data; let those fall through and fail.
+    label_match = _LABEL_RE.match(raw)
+    if label_match:
+        label_words = re.split(r'[:：]', label_match.group(0), maxsplit=1)[0].strip()
+        if label_words and dateparser.parse(label_words) is None:
+            raw = raw[label_match.end() :].strip()
+
+    # Strip no-colon label idioms (overridable default, never the source of truth).
+    strip_prefixes: tuple[str, ...] = config.get('strip_prefixes', _DEFAULT_STRIP_PREFIXES)
     lower = raw.lower()
-    for prefix in _STRIP_PREFIXES:
+    for prefix in strip_prefixes:
         if lower.startswith(prefix):
             raw = raw[len(prefix) :].strip()
             break

--- a/yosoi/types/price.py
+++ b/yosoi/types/price.py
@@ -2,8 +2,10 @@
 
 import re
 
-from yosoi.types.registry import KIND_NUMERIC, CoercionConfig, SemanticRule, register_coercion
+from yosoi.types.registry import KIND_NUMERIC, CoercionConfig, SemanticRule, matches_word, register_coercion
 
+# Default zero-price words. A DEFAULT, not the source of truth: override per field via
+# ys.Price(zero_value_words=('無料', 'gratuit', ...)) for non-English locales.
 _ZERO_VALUE_WORDS = ('free', 'complimentary', 'gratis')
 
 
@@ -13,6 +15,7 @@ _ZERO_VALUE_WORDS = ('free', 'complimentary', 'gratis')
     semantic=SemanticRule(kind=KIND_NUMERIC, max_chars=50),
     currency_symbol=None,
     require_decimals=False,
+    zero_value_words=_ZERO_VALUE_WORDS,
 )
 def Price(v: object, config: CoercionConfig, source_url: str | None = None) -> float:
     """Configure a price field with optional currency and decimal enforcement.
@@ -24,21 +27,24 @@ def Price(v: object, config: CoercionConfig, source_url: str | None = None) -> f
     """
     currency_symbol: str | None = config.get('currency_symbol')
     require_decimals: bool = config.get('require_decimals', False)
+    zero_value_words: tuple[str, ...] = config.get('zero_value_words', _ZERO_VALUE_WORDS)
 
     if not isinstance(v, str):
         return float(str(v))
 
     cleaned = v.strip().lower()
 
-    if any(word in cleaned for word in _ZERO_VALUE_WORDS):
-        return 0.0
+    match = re.search(r'\d+[.,\d]*', cleaned)
+    if not match:
+        # No number present — honour an explicit zero-value word. Whole-word for ASCII
+        # ("free shipping over $50" already took the numeric path above); substring for
+        # non-ASCII (CJK) overrides where \b does not fire. See registry.matches_word.
+        if any(matches_word(cleaned, word) for word in zero_value_words):
+            return 0.0
+        raise ValueError(f'No numeric value found in: {v!r}')
 
     if currency_symbol and currency_symbol not in v:
         raise ValueError(f'Price missing required currency symbol: {currency_symbol!r}')
-
-    match = re.search(r'\d+[.,\d]*', cleaned)
-    if not match:
-        raise ValueError(f'No numeric value found in: {v!r}')
 
     num_str = match.group(0)
 

--- a/yosoi/types/rating.py
+++ b/yosoi/types/rating.py
@@ -2,8 +2,10 @@
 
 import re
 
-from yosoi.types.registry import KIND_NUMERIC, CoercionConfig, SemanticRule, register_coercion
+from yosoi.types.registry import KIND_NUMERIC, CoercionConfig, SemanticRule, matches_word, register_coercion
 
+# Default English number-word map. A DEFAULT, not the source of truth: override per field
+# via ys.Rating(word_map={'trois': 3, ...}) for non-English review sites.
 _WORD_MAP = {
     'one': 1,
     'two': 2,
@@ -24,6 +26,7 @@ _WORD_MAP = {
     semantic=SemanticRule(kind=KIND_NUMERIC, max_chars=50),
     as_float=False,
     scale=5,
+    word_map=_WORD_MAP,
 )
 def Rating(v: object, config: CoercionConfig, source_url: str | None = None) -> float | str:
     """Configure a rating field with optional numeric conversion and scale validation.
@@ -36,6 +39,7 @@ def Rating(v: object, config: CoercionConfig, source_url: str | None = None) -> 
     """
     as_float: bool = config.get('as_float', False)
     scale: int = config.get('scale', 5)
+    word_map: dict[str, int] = config.get('word_map', _WORD_MAP)
 
     raw = str(v).strip()
 
@@ -43,8 +47,10 @@ def Rating(v: object, config: CoercionConfig, source_url: str | None = None) -> 
         return raw
 
     lower = raw.lower()
-    for word, num in _WORD_MAP.items():
-        if lower.startswith(word):
+    for word, num in word_map.items():
+        # Whole-word match — `startswith` wrongly matched "tens of reviews" → 10.
+        # `matches_word` escapes the word and handles non-ASCII (CJK) keys safely.
+        if matches_word(lower, word):
             return float(num)
 
     match = re.search(r'(\d+(?:\.\d+)?)', raw)

--- a/yosoi/types/registry.py
+++ b/yosoi/types/registry.py
@@ -9,6 +9,7 @@ interprets a small set of kinds, never the specific built-in type names.
 """
 
 import datetime
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -17,6 +18,21 @@ from yosoi.types.field import Field
 
 # Coercion config: json_schema_extra dict passed to coercion functions
 CoercionConfig = dict[str, str | int | float | bool | None]
+
+
+def matches_word(text: str, word: str) -> bool:
+    r"""Return whether *word* occurs in already-lowercased *text* as a whole word.
+
+    ASCII words use a regex word boundary (so ``free`` does not match ``freedom``) and
+    are regex-escaped (so a caller-supplied word with metacharacters can't raise); a
+    non-ASCII word (e.g. CJK) falls back to substring, since ``\b`` does not fire
+    between CJK characters.
+    """
+    w = word.lower()
+    if w.isascii():
+        return re.search(rf'\b{re.escape(w)}\b', text) is not None
+    return w in text
+
 
 # Coercion function return type (includes datetime for Datetime coercer)
 CoercedValue = str | float | int | datetime.datetime | None

--- a/yosoi/types/related_content.py
+++ b/yosoi/types/related_content.py
@@ -3,7 +3,7 @@
 from yosoi.types.registry import CoercionConfig, register_coercion
 
 
-@register_coercion('related_content', description='Related links (text + href pairs)')
+@register_coercion('related_content', description='Related links')
 def RelatedContent(v: object, config: CoercionConfig, source_url: str | None = None) -> str:
     """Configure a related content / links field.
 

--- a/yosoi/types/title.py
+++ b/yosoi/types/title.py
@@ -5,7 +5,7 @@ from yosoi.types.registry import KIND_TEXT, CoercionConfig, SemanticRule, regist
 
 @register_coercion(
     'title',
-    description='A title or heading',
+    description='A title',
     semantic=SemanticRule(kind=KIND_TEXT, max_chars=500, distinct=True),
 )
 def Title(v: object, config: CoercionConfig, source_url: str | None = None) -> str:

--- a/yosoi/types/url.py
+++ b/yosoi/types/url.py
@@ -7,9 +7,19 @@ from yosoi.types.registry import KIND_URL, CoercionConfig, SemanticRule, registe
 _TRACKING_PREFIXES = ('utm_', 'fbclid', 'gclid', '_gl', 'ref')
 
 
+def _is_tracking_param(param: str) -> bool:
+    """Return whether a ``key=value`` query param is a known tracking param.
+
+    Entries ending in ``_`` (e.g. ``utm_``) match by key prefix; every other entry must
+    match the key exactly — so ``ref`` strips ``ref=…`` but never ``reference=``/``ref_id=``.
+    """
+    key = param.split('=', 1)[0]
+    return any(key.startswith(t) if t.endswith('_') else key == t for t in _TRACKING_PREFIXES)
+
+
 @register_coercion(
     'url',
-    description='A URL or href',
+    description='A URL',
     semantic=SemanticRule(kind=KIND_URL, max_chars=500),
     require_https=True,
     strip_tracking=True,
@@ -40,9 +50,7 @@ def Url(v: object, config: CoercionConfig, source_url: str | None = None) -> str
 
     if strip_tracking and '?' in raw:
         parsed = urlparse(raw)
-        clean_params = [
-            p for p in parsed.query.split('&') if p and not any(p.startswith(t) for t in _TRACKING_PREFIXES)
-        ]
+        clean_params = [p for p in parsed.query.split('&') if p and not _is_tracking_param(p)]
         raw = urlunparse(parsed._replace(query='&'.join(clean_params))).rstrip('?')
 
     return raw

--- a/yosoi/utils/files.py
+++ b/yosoi/utils/files.py
@@ -127,6 +127,17 @@ async def atomic_write_json_async(
     await atomic_write_text_async(path, json.dumps(data, indent=indent, ensure_ascii=ensure_ascii))
 
 
+def safe_domain(domain: str) -> str:
+    """Return a filesystem-safe form of a domain for use in cache filenames.
+
+    Single source of truth for the per-domain cache key. Replaces the
+    ``domain.replace('.', '_')...`` snippets that were copied across the storage modules
+    and had drifted (some stripped ``:``, some did not), so the same domain always maps
+    to the same on-disk filename across every store.
+    """
+    return domain.replace('.', '_').replace('/', '_').replace(':', '_')
+
+
 def get_project_root() -> Path:
     """Find the project root by searching upwards from the Current Working Directory.
 

--- a/yosoi/utils/urls.py
+++ b/yosoi/utils/urls.py
@@ -3,9 +3,30 @@
 import json
 import os
 import re
+from urllib.parse import urlparse
 
 _URL_RE = re.compile(r'https?://[^\s\'"<>]+')
 _MD_LINK_RE = re.compile(r'\[([^\]]*)\]\((https?://[^)]+)\)')
+
+
+def extract_domain(url: str) -> str:
+    """Return the normalized host for a URL — lowercased, leading ``www.`` stripped, no port.
+
+    Single source of truth for the per-domain cache key on the storage/fetch path. Using
+    ``hostname`` (not ``netloc``) and lowercasing means the same site never forks the cache
+    across mixed-case hosts, ports, or userinfo — which would silently break
+    "discover once, scrape forever". Returns ``'unknown'`` for an unparseable URL.
+    """
+    try:
+        host = urlparse(url).hostname
+    except ValueError:
+        return 'unknown'
+    if not host:
+        return 'unknown'
+    host = host.lower()
+    if host.startswith('www.') and len(host) > 4:
+        host = host[4:]
+    return host
 
 
 try:


### PR DESCRIPTION
…… (#90)

* feat(CAS-94): de-hardcode coercion, descriptions, selectors + selector-level A3Node replay

Strip hard-coded / site-shaped heuristics across the codebase so behavior is data, not code (CAS-94). Highlights:

- types: fix coercion bugs (rating whole-word vs startswith, price numeric-first vs substring zero-words, url exact-key vs over-broad 'ref' tracking) and make the English/locale lists overridable defaults (rating word_map, price zero_value_words, datetime strip_prefixes + a language-agnostic label strip).
- descriptions: remove DOM-structure language from contract defaults, the discovery prompt guides, the orchestrator root description, and type defaults.
- strategy: derive VALID_SELECTOR_LEVELS from canonical SelectorKind (was a stale subset silently dropping cached attr/role/global_id/visual) + fix the matching writer in pipeline.py.
- probes: replace the fabricated `content_count % 10` infinite-scroll signal with a real eval_js scrollability check.
- cleaner: drop dangerous [class*="ad-"] substring matchers and content-bearing .related-posts / .useful-links (they conflict with ys.RelatedContent).
- CAS-94 core: A3Node ActRecord carries a SelectorEntry target (format 2, back-compat); replay clicks it directly so the catalogues are OFF the replay hot path (now a cold-start seed + fallback). replay_count/battle_tested preserved across the format upgrade.
- single-source: safe_domain(), extract_domain() (fixes per-domain cache fork on mixed-case/ported hosts), HARD_BLOCK_STATUS.
- examples: replay_demo.py (no-LLM replay) + discovery_demo.py (keyless Claude SDK / OpenCode discovery) for Google Maps, reddit, qscrape.

Follow-ups tracked in CAS-146.



* fix(CAS-94): address pre-merge review — datetime label corruption, CJK/escape, A3Node domain key

3-lens pre-merge review findings:
- datetime: the generic leading-"Label:" strip no longer eats a date-word label ("March: 2020"), which dateparser silently backfilled from today (fail-fast → garbage). The strip now fires only when the label itself is NOT a parseable date.
- rating/price: share registry.matches_word — ASCII words are regex-escaped (a custom word_map / zero_value_words key with metacharacters no longer raises re.error) and non-ASCII (CJK) falls back to substring where \b doesn't fire ("無料です" → 0.0, "三つ星" → 3.0).
- voiddriver: A3Node cache key now uses extract_domain (the last un-migrated netloc site) so the recipe key can't fork on mixed-case/ported hosts.
- tests: regressions for each (March: raises, CJK rating/price, metachar word_map, road-map survives the cleaner).



---------

<!-- Link the issue this PR addresses. If there is no issue, consider creating one first. -->

- Closes #<issue>

## Intent

<!-- What does this PR do and why? -->

## Changes

<!-- Summarize what was changed. -->

## GenAI Usage

- [ ] AI-generated code was used in this PR

<!-- If checked, briefly describe how AI was used (e.g., tool, prompts, which parts). -->
<!-- All AI-generated code must be reviewed line-by-line by the PR author. -->

## Risks

<!-- Any risks or side effects this change might introduce? If none, write "None." -->

## Checklist

- [ ] Branch is based on `main`
- [ ] CI passes (lint, type check, tests)
- [ ] Changes are focused -one logical change per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
